### PR TITLE
WIP docs: repo and community documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners
+@richardcase @rajarajanpsj

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+title: ''
+labels: kind/bug
+assignees: ''
+---
+
+**What happened:**
+[A clear and concise description of what the bug is.]
+
+
+**What did you expect to happen:**
+
+
+**How to reproduce it:**
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- kconnect version (use `kconnect version`):
+- Kubernetes version (use `kubectl version`): 
+- OS (e.g. from `/etc/os-release`):
+- Target environment (e.g. EKS, AKS, Rancher):
+- Authentication Used (e.g. SAML, IAM, Azure AD):  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # kconnect - The Kubernetes Connection Manager CLI
 
+## What is kconnect?
+
+kconnect is a CLI utility that can be used to discover and securely access Kubernetes clusters across multiple operating environments.
+
+Based on the authentication mechanism chosen the CLI will discover Kubernetes clusters you are allowed to access in a target hosting environment (i.e. EKS, AKS, Rancher) and generate a kubeconfig for a chosen cluster.
+
+## Installation
+
+There are currently no releases. This section will be updated with installation instructions.
+
+## Documentation
+
+Documentation is contained in the `/docs` directory. The [index is here](docs/README.md). 
+
+## Contributions
+
+Contributions are very welcome. We will be publishing a contributing guide soon to help.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,6 @@
+## Community Code of Conduct
+
+kconnect follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+must be reported by contacting a _kconnect_ project maintainer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# kconnect Documentation
+
+- [Initial Design](design.md)


### PR DESCRIPTION
Added some initial base documentation and template files that
are expected of the repo for OSS.

Relates to: #2, #5, #6