### PR TITLE
chore: added prelease to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,9 @@ builds:
       goarch:
         - amd64
 
+release:
+    prerelease: auto
+
 archives:
     -
       id: default
@@ -47,4 +50,5 @@ changelog:
             - '^test:'
             - '^chore:'
             - '^style:'
+            - '^Merge'
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the `prelease: auto` to the goreleaser configuration so that releases in GitHub are marked as pre-release if there is any indicator after the semver version number.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #