### PR TITLE
chore: remove rougue print and CA cert is base 64 decoded

### DIFF
--- a/pkg/flags/unmarshal.go
+++ b/pkg/flags/unmarshal.go
@@ -145,7 +145,6 @@ func (b *flagBinder) Unmarshal(flagset *pflag.FlagSet, out interface{}) error {
 
 func unmarshallFlag(flag *pflag.Flag, out reflect.Value) error {
 	fieldT := out.Type()
-	fmt.Println(fieldT.Kind())
 
 	flagValueStr := flag.Value.String()
 

--- a/pkg/plugins/discovery/aws/config.go
+++ b/pkg/plugins/discovery/aws/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -29,11 +30,16 @@ func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *pr
 	userName := fmt.Sprintf("kconnect-%s", p.identity.ProfileName)
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
 
+	certData, err := base64.StdEncoding.DecodeString(*cluster.CertificateAuthorityData)
+	if err != nil {
+		return nil, fmt.Errorf("decoding certificate: %w", err)
+	}
+
 	cfg := &api.Config{
 		Clusters: map[string]*api.Cluster{
 			clusterName: {
 				Server:                   *cluster.ControlPlaneEndpoint,
-				CertificateAuthorityData: []byte(*cluster.CertificateAuthorityData),
+				CertificateAuthorityData: certData,
 			},
 		},
 		Contexts: map[string]*api.Context{


### PR DESCRIPTION
**What this PR does / why we need it**:
The CA cert for EKS needs to be base64 decoded

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #