### PR TITLE
feat: allow setting current context

### DIFF
--- a/internal/app/use.go
+++ b/internal/app/use.go
@@ -26,6 +26,7 @@ import (
 // UseParams are the parameters to the use function
 type UseParams struct {
 	Kubeconfig       string
+	SetCurrent       bool
 	IdpProtocol      string
 	Provider         provider.ClusterProvider
 	IdentityProvider provider.IdentityProvider
@@ -38,7 +39,7 @@ func (a *App) Use(params *UseParams) error {
 
 	provider := params.Provider
 
-	a.logger.Infof("Disovering clusters using %s provider", provider.Name())
+	a.logger.Infof("Discovering clusters using %s provider", provider.Name())
 	discoverOutput, err := provider.Discover(params.Context, params.Identity)
 	if err != nil {
 		return fmt.Errorf("discovering clusters using %s: %w", provider.Name(), err)
@@ -54,7 +55,7 @@ func (a *App) Use(params *UseParams) error {
 		return fmt.Errorf("selecting cluster: %w", err)
 	}
 
-	kubeConfig, err := provider.GetClusterConfig(params.Context, cluster)
+	kubeConfig, err := provider.GetClusterConfig(params.Context, cluster, params.SetCurrent)
 	if err != nil {
 		return fmt.Errorf("creating kubeconfig for %s: %w", cluster.Name, err)
 	}

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -69,6 +69,7 @@ func Command() *cobra.Command {
 	}
 
 	useCmd.Flags().StringVar(&params.IdpProtocol, "idp-protocol", "", "the idp protocol to use (e.g. saml)")
+	useCmd.Flags().BoolVar(&params.SetCurrent, "set-current", false, "sets the current context in the kubeconfig to selected cluster")
 	provider.AddKubeconfigFlag(useCmd)
 	provider.AddCommonIdentityFlags(useCmd)
 	provider.AddCommonClusterProviderFlags(useCmd)

--- a/pkg/plugins/discovery/aws/config.go
+++ b/pkg/plugins/discovery/aws/config.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/provider"
 )
 
-func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster) (*api.Config, error) {
+func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster, setCurrent bool) (*api.Config, error) {
 	clusterName := fmt.Sprintf("kconnect-eks-%s", cluster.Name)
 	userName := fmt.Sprintf("kconnect-%s", p.identity.ProfileName)
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
@@ -70,6 +70,11 @@ func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *pr
 		userName: {
 			Exec: execConfig,
 		},
+	}
+
+	if setCurrent {
+		p.logger.Infof("setting current context to: %s", contextName)
+		cfg.CurrentContext = contextName
 	}
 
 	return cfg, nil

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -33,7 +33,7 @@ type ClusterProvider interface {
 	// Discover will discover what clusters the supplied identity has access to
 	Discover(ctx *Context, identity Identity) (*DiscoverOutput, error)
 
-	GetClusterConfig(ctx *Context, cluster *Cluster) (*api.Config, error)
+	GetClusterConfig(ctx *Context, cluster *Cluster, setCurrent bool) (*api.Config, error)
 
 	// FlagsResolver returns the resolver used to inetractively resolve flags
 	FlagsResolver() FlagsResolver


### PR DESCRIPTION
**What this PR does / why we need it**:
When a cluster is selected and the kubeconfig is generated there
is now an option to make that context the current by using
the new `--set-current` flag with the `use` command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68 