### PR TITLE
refactor: introduce config set instead of using flagset everywhere

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,4 @@ linters:
     - whitespace
     - godot
     - godox
+    - maligned

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package usage
 
 import (
@@ -5,6 +21,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/fidelity/kconnect/pkg/flags"
 	"github.com/fidelity/kconnect/pkg/provider"
 	"github.com/spf13/cobra"
 )
@@ -21,9 +38,13 @@ func Get(cmd *cobra.Command) error {
 	}
 
 	for _, provider := range providers {
-		if provider.Flags() != nil {
+		if provider.ConfigurationItems() != nil {
 			usage = append(usage, fmt.Sprintf("\n%s provider flags:", provider.Name()))
-			usage = append(usage, strings.TrimRightFunc(provider.Flags().FlagUsages(), unicode.IsSpace))
+			providerFlags, err := flags.CreateFlagsFromConfig(provider.ConfigurationItems())
+			if err != nil {
+				return fmt.Errorf("converting provider config to flags: %w", err)
+			}
+			usage = append(usage, strings.TrimRightFunc(providerFlags.FlagUsages(), unicode.IsSpace))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,10 @@ import (
 )
 
 func main() {
-	rootCmd := commands.RootCmd()
+	rootCmd, err := commands.RootCmd()
+	if err != nil {
+		logrus.Fatal(err)
+	}
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/aws/clients.go
+++ b/pkg/aws/clients.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package aws
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "errors"
+
+var (
+	ErrConfigExistsAlready = errors.New("config item with same name already exists in set")
+	ErrConfigNotFound      = errors.New("configuration item not found")
+	ErrUnknownItemType     = errors.New("unknown item type for config item")
+)
+
+// Item represents a configuration item
+type Item struct {
+	Name             string
+	Shorthand        string
+	Type             ItemType
+	Sensitive        bool
+	Description      string
+	ResolutionPrompt string
+	Value            interface{}
+	DefaultValue     interface{}
+	Required         bool
+}
+
+type ItemType string
+
+var (
+	ItemTypeString = ItemType("string")
+	ItemTypeInt    = ItemType("int")
+	ItemTypeBool   = ItemType("bool")
+)
+
+type ConfigurationSet interface {
+	Get(name string) *Item
+	GetAll() []*Item
+	Exists(name string) bool
+	ExistsWithValue(name string) bool
+	Add(item *Item) error
+	AddSet(set ConfigurationSet) error
+	SetSensitive(name string) error
+	SetRequired(name string) error
+	SetValue(name string, value interface{}) error
+	SetShort(name string, shorthand string) error
+
+	String(name string, defaultValue string, description string) (*Item, error)
+	Int(name string, defaultValue int, description string) (*Item, error)
+	Bool(name string, defaultValue bool, description string) (*Item, error)
+}
+
+func NewConfigurationSet() ConfigurationSet {
+	return &configSet{
+		config: make(map[string]*Item),
+	}
+}
+
+type configSet struct {
+	config map[string]*Item
+}
+
+func (s *configSet) Exists(name string) bool {
+	return s.Get(name) != nil
+}
+
+func (s *configSet) ExistsWithValue(name string) bool {
+	item := s.Get(name)
+	if item == nil {
+		return false
+	}
+
+	if item.Value == nil {
+		return false
+	}
+
+	if item.Type == ItemTypeString {
+		return item.Value.(string) != ""
+	}
+
+	return true
+}
+
+func (s *configSet) Get(name string) *Item {
+	return s.config[name]
+}
+
+func (s *configSet) GetAll() []*Item {
+	items := []*Item{}
+	for _, item := range s.config {
+		items = append(items, item)
+	}
+
+	return items
+}
+
+func (s *configSet) Add(item *Item) error {
+	_, exists := s.config[item.Name]
+	if exists {
+		return ErrConfigExistsAlready
+	}
+	s.config[item.Name] = item
+
+	return nil
+}
+
+func (s *configSet) AddSet(setToAdd ConfigurationSet) error {
+	if setToAdd == nil {
+		return nil
+	}
+
+	for _, item := range setToAdd.GetAll() {
+		if !s.Exists(item.Name) {
+			if err := s.Add(item); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *configSet) SetSensitive(name string) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.Sensitive = true
+
+	return nil
+}
+
+func (s *configSet) SetRequired(name string) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.Required = true
+
+	return nil
+}
+
+func (s *configSet) SetValue(name string, value interface{}) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.Value = value
+
+	return nil
+}
+
+func (s *configSet) SetShort(name string, shorthand string) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.Shorthand = shorthand
+
+	return nil
+}
+
+func (s *configSet) String(name string, defaultValue string, description string) (*Item, error) {
+	item := &Item{
+		Name:         name,
+		Type:         ItemTypeString,
+		DefaultValue: defaultValue,
+		Description:  description,
+	}
+
+	if err := s.Add(item); err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+func (s *configSet) Int(name string, defaultValue int, description string) (*Item, error) {
+	item := &Item{
+		Name:         name,
+		Type:         ItemTypeInt,
+		DefaultValue: defaultValue,
+		Description:  description,
+	}
+
+	if err := s.Add(item); err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+func (s *configSet) Bool(name string, defaultValue bool, description string) (*Item, error) {
+	item := &Item{
+		Name:         name,
+		Type:         ItemTypeBool,
+		DefaultValue: defaultValue,
+		Description:  description,
+	}
+
+	if err := s.Add(item); err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}

--- a/pkg/config/unmarshall.go
+++ b/pkg/config/unmarshall.go
@@ -14,10 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package plugins
+package config
 
 import (
-	// Initialize all the identity, discovery and resolver plugins
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery"
-	_ "github.com/fidelity/kconnect/pkg/plugins/identity"
+	"encoding/json"
 )
+
+// Unmarshall will unmarshall the ConfigurationSet into a struct
+func Unmarshall(cs ConfigurationSet, out interface{}) error {
+	items := make(map[string]interface{})
+	for _, item := range cs.GetAll() {
+		items[item.Name] = item.Value
+	}
+
+	data, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(data, out); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/k8s/kubeconfig/kubeconfig.go
+++ b/pkg/k8s/kubeconfig/kubeconfig.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubeconfig
 
 import (

--- a/pkg/plugins/discovery/plugins.go
+++ b/pkg/plugins/discovery/plugins.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package discovery
 
 import (

--- a/pkg/plugins/identity/empty/empty.go
+++ b/pkg/plugins/identity/empty/empty.go
@@ -18,8 +18,8 @@ package identity
 
 import (
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/provider"
 )
 
@@ -48,7 +48,7 @@ func (p *emptyIdentityProvider) Name() string {
 }
 
 // Flags will return the flags for this plugin
-func (p *emptyIdentityProvider) Flags() *pflag.FlagSet {
+func (p *emptyIdentityProvider) ConfigurationItems() config.ConfigurationSet {
 	return nil
 }
 

--- a/pkg/plugins/identity/plugins.go
+++ b/pkg/plugins/identity/plugins.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package discovery
 
 import (

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -22,9 +22,7 @@ import (
 	"fmt"
 
 	"github.com/beevik/etree"
-	"github.com/go-playground/validator/v10"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -35,7 +33,7 @@ import (
 	"github.com/versent/saml2aws/pkg/awsconfig"
 	"github.com/versent/saml2aws/pkg/cfg"
 
-	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/plugins/identity/saml/sp"
 	"github.com/fidelity/kconnect/pkg/provider"
 )
@@ -53,12 +51,12 @@ var (
 	ErrMissingResponseElement = errors.New("missing response element")
 )
 
-type awsProviderConfig struct {
-	sp.ProviderConfig
+// type awsProviderConfig struct {
+// 	sp.ProviderConfig
 
-	Region  string `flag:"region" validate:"required"`
-	Profile string `flag:"profile" validate:"required"`
-}
+// 	Region  string `flag:"region" validate:"required"`
+// 	Profile string `flag:"profile" validate:"required"`
+// }
 
 func NewServiceProvider(logger *log.Entry) sp.ServiceProvider {
 	return &ServiceProvider{
@@ -71,26 +69,25 @@ type ServiceProvider struct {
 	session client.ConfigProvider
 }
 
-func (p *ServiceProvider) PopulateAccount(account *cfg.IDPAccount, flags *pflag.FlagSet) error {
+func (p *ServiceProvider) PopulateAccount(account *cfg.IDPAccount, cfg config.ConfigurationSet) error {
 	account.AmazonWebservicesURN = "urn:amazon:webservices"
 
-	regionFlag := flags.Lookup("region")
-	if regionFlag == nil || regionFlag.Value.String() == "" {
+	regionCfg := cfg.Get("region")
+	if regionCfg == nil || regionCfg.Value.(string) == "" {
 		return ErrNoRegion
 	}
-	account.Region = regionFlag.Value.String()
+	account.Region = regionCfg.Value.(string)
 
-	profileFlag := flags.Lookup("profile")
-	if profileFlag == nil || profileFlag.Value.String() == "" {
+	profileCfg := cfg.Get("profile")
+	if profileCfg == nil || profileCfg.Value.(string) == "" {
 		return ErrNoProfile
 	}
-	account.Profile = profileFlag.Value.String()
+	account.Profile = profileCfg.Value.(string)
 
-	roleFlag := flags.Lookup("role-arn")
-	if roleFlag != nil || roleFlag.Value.String() != "" {
-		account.RoleARN = roleFlag.Value.String()
+	roleCfg := cfg.Get("role-arn")
+	if roleCfg != nil || roleCfg.Value.(string) != "" {
+		account.RoleARN = roleCfg.Value.(string)
 	}
-	account.Region = regionFlag.Value.String()
 
 	return nil
 }
@@ -246,17 +243,18 @@ func (p *ServiceProvider) extractDestinationURL(data []byte) (string, error) {
 	return "", fmt.Errorf("getting response element Destination or SubjectConfirmationData: %w", ErrMissingResponseElement)
 }
 
-func (p *ServiceProvider) Validate(ctx *provider.Context, flagset *pflag.FlagSet) error {
-	config := &awsProviderConfig{}
+func (p *ServiceProvider) Validate(configItems config.ConfigurationSet) error {
+	//TODO: handle this
+	// config := &awsProviderConfig{}
 
-	if err := flags.Unmarshal(flagset, config); err != nil {
-		return fmt.Errorf("unmarshlling flags to config: %w", err)
-	}
+	// if err := flags.Unmarshal(flagset, config); err != nil {
+	// 	return fmt.Errorf("unmarshlling flags to config: %w", err)
+	// }
 
-	validate := validator.New()
-	if err := validate.Struct(config); err != nil {
-		return fmt.Errorf("validating config struct: %w", err)
-	}
+	// validate := validator.New()
+	// if err := validate.Struct(config); err != nil {
+	// 	return fmt.Errorf("validating config struct: %w", err)
+	// }
 
 	return nil
 }

--- a/pkg/plugins/identity/saml/sp/aws/resolver.go
+++ b/pkg/plugins/identity/saml/sp/aws/resolver.go
@@ -22,39 +22,35 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/fidelity/kconnect/pkg/aws"
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
-	"github.com/fidelity/kconnect/pkg/provider"
 )
 
 // Resolve will resolve the values for the AWS specific flags that have no value. It will
 // query AWS and interactively ask the user for selections.
-func (p *ServiceProvider) ResolveFlags(ctx *provider.Context, flagset *pflag.FlagSet) error {
-	p.logger.Debug("resolving AWS identity flags")
+func (p *ServiceProvider) ResolveConfiguration(cfg config.ConfigurationSet) error {
+	p.logger.Debug("resolving AWS identity configuration items")
 
 	// TODO: handle in declarative mannor
 	// NOTE: resolution is only needed for required fields
-	if err := p.resolveIdpProvider("idp-provider", flagset); err != nil {
+	if err := p.resolveIdpProvider("idp-provider", cfg); err != nil {
 		return fmt.Errorf("resolving idp-provider: %w", err)
 	}
-	if err := p.resolveIdpEndpoint("idp-endpoint", flagset); err != nil {
+	if err := p.resolveIdpEndpoint("idp-endpoint", cfg); err != nil {
 		return fmt.Errorf("resolving idp-endpoint: %w", err)
 	}
-	if err := p.resolveProfile("profile", flagset); err != nil {
+	if err := p.resolveProfile("profile", cfg); err != nil {
 		return fmt.Errorf("resolving profile: %w", err)
 	}
-	if err := p.resolveRegion("region", flagset); err != nil {
+	if err := p.resolveRegion("region", cfg); err != nil {
 		return fmt.Errorf("resolving region: %w", err)
 	}
-	if err := p.resolveUsername("username", flagset); err != nil {
+	if err := p.resolveUsername("username", cfg); err != nil {
 		return fmt.Errorf("resolving username: %w", err)
 	}
-	if err := p.resolvePassword("password", flagset); err != nil {
+	if err := p.resolvePassword("password", cfg); err != nil {
 		return fmt.Errorf("resolving password: %w", err)
 	}
-
-	// if err := r.resolveRoleARN("role-arn", flagset); err != nil {
-	// 	return fmt.Errorf("resolving role-arn: %w", err)
-	// }
 
 	return nil
 }

--- a/pkg/plugins/identity/saml/sp/aws/resolver_debug.go
+++ b/pkg/plugins/identity/saml/sp/aws/resolver_debug.go
@@ -21,11 +21,11 @@ package aws
 import (
 	"fmt"
 
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
-	"github.com/spf13/pflag"
 )
 
-func (p *ServiceProvider) resolveProfile(name string, flagset *pflag.FlagSet) error {
+func (p *ServiceProvider) resolveProfile(name string, cfg config.ConfigurationSet) error {
 	if flags.ExistsWithValue(name, flagset) {
 		return nil
 	}
@@ -40,7 +40,7 @@ func (p *ServiceProvider) resolveProfile(name string, flagset *pflag.FlagSet) er
 	return nil
 }
 
-func (p *ServiceProvider) resolveRegion(name string, flagset *pflag.FlagSet) error {
+func (p *ServiceProvider) resolveRegion(name string, cfg config.ConfigurationSet) error {
 	if flags.ExistsWithValue(name, flagset) {
 		return nil
 	}
@@ -55,7 +55,7 @@ func (p *ServiceProvider) resolveRegion(name string, flagset *pflag.FlagSet) err
 	return nil
 }
 
-func (p *ServiceProvider) resolveUsername(name string, flagset *pflag.FlagSet) error {
+func (p *ServiceProvider) resolveUsername(name string, cfg config.ConfigurationSet) error {
 	if flags.ExistsWithValue(name, flagset) {
 		return nil
 	}
@@ -70,7 +70,7 @@ func (p *ServiceProvider) resolveUsername(name string, flagset *pflag.FlagSet) e
 	return nil
 }
 
-func (p *ServiceProvider) resolvePassword(name string, flagset *pflag.FlagSet) error {
+func (p *ServiceProvider) resolvePassword(name string, cfg config.ConfigurationSet) error {
 	if flags.ExistsWithValue(name, flagset) {
 		return nil
 	}
@@ -86,7 +86,7 @@ func (p *ServiceProvider) resolvePassword(name string, flagset *pflag.FlagSet) e
 	return nil
 }
 
-func (p *ServiceProvider) resolveIdpEndpoint(name string, flagset *pflag.FlagSet) error {
+func (p *ServiceProvider) resolveIdpEndpoint(name string, cfg config.ConfigurationSet) error {
 	if flags.ExistsWithValue(name, flagset) {
 		return nil
 	}
@@ -101,7 +101,7 @@ func (p *ServiceProvider) resolveIdpEndpoint(name string, flagset *pflag.FlagSet
 	return nil
 }
 
-func (p *ServiceProvider) resolveIdpProvider(name string, flagset *pflag.FlagSet) error {
+func (p *ServiceProvider) resolveIdpProvider(name string, cfg config.ConfigurationSet) error {
 	if flags.ExistsWithValue(name, flagset) {
 		return nil
 	}
@@ -115,18 +115,3 @@ func (p *ServiceProvider) resolveIdpProvider(name string, flagset *pflag.FlagSet
 
 	return nil
 }
-
-// func (r *ServiceProvider) resolveRoleARN(name string, flagset *pflag.FlagSet) error {
-// 	if flags.ExistsWithValue(name, flagset) {
-// 		return nil
-// 	}
-
-// 	roleArn := "some role"
-
-// 	if err := flagset.Set(name, roleArn); err != nil {
-// 		r.logger.Errorf("failed setting role-arn flag to %s: %s", role-arn, err.Error())
-// 		return fmt.Errorf("setting role-arn flag: %w", err)
-// 	}
-
-// 	return nil
-// }

--- a/pkg/plugins/identity/saml/sp/aws/resolver_interactive.go
+++ b/pkg/plugins/identity/saml/sp/aws/resolver_interactive.go
@@ -22,13 +22,12 @@ import (
 	"fmt"
 
 	survey "github.com/AlecAivazis/survey/v2"
-	"github.com/spf13/pflag"
 
-	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/fidelity/kconnect/pkg/config"
 )
 
-func (p *ServiceProvider) resolveProfile(name string, flagset *pflag.FlagSet) error {
-	if flags.ExistsWithValue(name, flagset) {
+func (p *ServiceProvider) resolveProfile(name string, cfg config.ConfigurationSet) error {
+	if cfg.ExistsWithValue(name) {
 		return nil
 	}
 
@@ -40,7 +39,7 @@ func (p *ServiceProvider) resolveProfile(name string, flagset *pflag.FlagSet) er
 		return fmt.Errorf("asking for profile name: %w", err)
 	}
 
-	if err := flagset.Set(name, profile); err != nil {
+	if err := cfg.SetValue(name, profile); err != nil {
 		p.logger.Errorf("failed setting profile flag to %s: %s", profile, err.Error())
 		return fmt.Errorf("setting profile flag: %w", err)
 	}
@@ -48,8 +47,8 @@ func (p *ServiceProvider) resolveProfile(name string, flagset *pflag.FlagSet) er
 	return nil
 }
 
-func (p *ServiceProvider) resolveRegion(name string, flagset *pflag.FlagSet) error {
-	if flags.ExistsWithValue(name, flagset) {
+func (p *ServiceProvider) resolveRegion(name string, cfg config.ConfigurationSet) error {
+	if cfg.ExistsWithValue(name) {
 		return nil
 	}
 
@@ -62,7 +61,7 @@ func (p *ServiceProvider) resolveRegion(name string, flagset *pflag.FlagSet) err
 		return fmt.Errorf("asking for region name: %w", err)
 	}
 
-	if err := flagset.Set(name, region); err != nil {
+	if err := cfg.SetValue(name, region); err != nil {
 		p.logger.Errorf("failed setting region flag to %s: %s", region, err.Error())
 		return fmt.Errorf("setting region flag: %w", err)
 	}
@@ -70,8 +69,8 @@ func (p *ServiceProvider) resolveRegion(name string, flagset *pflag.FlagSet) err
 	return nil
 }
 
-func (p *ServiceProvider) resolveUsername(name string, flagset *pflag.FlagSet) error {
-	if flags.ExistsWithValue(name, flagset) {
+func (p *ServiceProvider) resolveUsername(name string, cfg config.ConfigurationSet) error {
+	if cfg.ExistsWithValue(name) {
 		return nil
 	}
 
@@ -83,7 +82,7 @@ func (p *ServiceProvider) resolveUsername(name string, flagset *pflag.FlagSet) e
 		return fmt.Errorf("asking for username name: %w", err)
 	}
 
-	if err := flagset.Set(name, username); err != nil {
+	if err := cfg.SetValue(name, username); err != nil {
 		p.logger.Errorf("failed setting username flag to %s: %s", username, err.Error())
 		return fmt.Errorf("setting username flag: %w", err)
 	}
@@ -91,8 +90,8 @@ func (p *ServiceProvider) resolveUsername(name string, flagset *pflag.FlagSet) e
 	return nil
 }
 
-func (p *ServiceProvider) resolvePassword(name string, flagset *pflag.FlagSet) error {
-	if flags.ExistsWithValue(name, flagset) {
+func (p *ServiceProvider) resolvePassword(name string, cfg config.ConfigurationSet) error {
+	if cfg.ExistsWithValue(name) {
 		return nil
 	}
 
@@ -105,7 +104,7 @@ func (p *ServiceProvider) resolvePassword(name string, flagset *pflag.FlagSet) e
 		return fmt.Errorf("asking for password name: %w", err)
 	}
 
-	if err := flagset.Set(name, password); err != nil {
+	if err := cfg.SetValue(name, password); err != nil {
 		p.logger.Errorf("failed setting password flag to %s: %s", password, err.Error())
 		return fmt.Errorf("setting password flag: %w", err)
 	}
@@ -113,8 +112,8 @@ func (p *ServiceProvider) resolvePassword(name string, flagset *pflag.FlagSet) e
 	return nil
 }
 
-func (p *ServiceProvider) resolveIdpEndpoint(name string, flagset *pflag.FlagSet) error {
-	if flags.ExistsWithValue(name, flagset) {
+func (p *ServiceProvider) resolveIdpEndpoint(name string, cfg config.ConfigurationSet) error {
+	if cfg.ExistsWithValue(name) {
 		return nil
 	}
 
@@ -126,7 +125,7 @@ func (p *ServiceProvider) resolveIdpEndpoint(name string, flagset *pflag.FlagSet
 		return fmt.Errorf("asking for idp-endpoint name: %w", err)
 	}
 
-	if err := flagset.Set(name, endpoint); err != nil {
+	if err := cfg.SetValue(name, endpoint); err != nil {
 		p.logger.Errorf("failed setting idp-endpoint flag to %s: %s", endpoint, err.Error())
 		return fmt.Errorf("setting idp-endpoint flag: %w", err)
 	}
@@ -134,8 +133,8 @@ func (p *ServiceProvider) resolveIdpEndpoint(name string, flagset *pflag.FlagSet
 	return nil
 }
 
-func (p *ServiceProvider) resolveIdpProvider(name string, flagset *pflag.FlagSet) error {
-	if flags.ExistsWithValue(name, flagset) {
+func (p *ServiceProvider) resolveIdpProvider(name string, cfg config.ConfigurationSet) error {
+	if cfg.ExistsWithValue(name) {
 		return nil
 	}
 	//TODO: get this from saml2aws????
@@ -150,37 +149,10 @@ func (p *ServiceProvider) resolveIdpProvider(name string, flagset *pflag.FlagSet
 		return fmt.Errorf("asking for idp-provider: %w", err)
 	}
 
-	if err := flagset.Set(name, idpProvider); err != nil {
+	if err := cfg.SetValue(name, idpProvider); err != nil {
 		p.logger.Errorf("failed setting idp-provider flag to %s: %s", idpProvider, err.Error())
 		return fmt.Errorf("setting idp-provider flag: %w", err)
 	}
 
 	return nil
 }
-
-// func (r *ServiceProvider) resolveRoleARN(name string, flagset *pflag.FlagSet) error {
-// 	if flags.ExistsWithValue(name, flagset) {
-// 		return nil
-// 	}
-
-// 	if err := r.ensureSessionFromFlags(flagset); err != nil {
-// 		return fmt.Errorf("ensuring aws session: %w", err)
-// 	}
-
-// 	iamClient := aws.NewIAMClient(r.session)
-
-// 	input := &iam.ListRolesInput{}
-
-// 	roles := []*iam.Role{}
-// 	err := iamClient.ListRolesPages(input, func(page *iam.ListRolesOutput, lastPage bool) bool {
-// 		roles = append(roles, page.Roles...)
-// 		return true
-// 	})
-// 	if err != nil {
-// 		return fmt.Errorf("listing iam roles: %w", err)
-// 	}
-
-// 	//TODO: prompt user
-
-// 	return nil
-// }

--- a/pkg/plugins/identity/saml/sp/aws/store.go
+++ b/pkg/plugins/identity/saml/sp/aws/store.go
@@ -19,21 +19,21 @@ package aws
 import (
 	"fmt"
 
-	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/provider"
-	"github.com/spf13/pflag"
 	"github.com/versent/saml2aws/pkg/awsconfig"
 )
 
 // NewIdentityStore will create a new AWS identity store
-func NewIdentityStore(providerFlags *pflag.FlagSet) (provider.IdentityStore, error) {
-	if !flags.ExistsWithValue("profile", providerFlags) {
+func NewIdentityStore(cfg config.ConfigurationSet) (provider.IdentityStore, error) {
+	if !cfg.ExistsWithValue("profile") {
 		return nil, ErrNoProfile
 	}
-	profileFlag := providerFlags.Lookup("profile")
+	profileCfg := cfg.Get("profile")
+	profile := profileCfg.Value.(string)
 
 	return &awsIdentityStore{
-		configProvider: awsconfig.NewSharedCredentials(profileFlag.Value.String()),
+		configProvider: awsconfig.NewSharedCredentials(profile),
 	}, nil
 }
 

--- a/pkg/plugins/identity/saml/sp/types.go
+++ b/pkg/plugins/identity/saml/sp/types.go
@@ -17,21 +17,21 @@ limitations under the License.
 package sp
 
 import (
-	"github.com/spf13/pflag"
 	"github.com/versent/saml2aws/pkg/cfg"
 
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/provider"
 )
 
 type ProviderConfig struct {
 	provider.IdentityProviderConfig
-	IdpEndpoint string `flag:"idp-endpoint" validate:"required"`
-	IdpProvider string `flag:"idp-provider" validate:"required"`
+	IdpEndpoint string `flag:"idp-endpoint" validate:"required" json:"idp-endpoint"`
+	IdpProvider string `flag:"idp-provider" validate:"required" json:"idp-provider"`
 }
 
 type ServiceProvider interface {
-	Validate(ctx *provider.Context, flags *pflag.FlagSet) error
-	ResolveFlags(ctx *provider.Context, flags *pflag.FlagSet) error
-	PopulateAccount(account *cfg.IDPAccount, flags *pflag.FlagSet) error
+	Validate(configItems config.ConfigurationSet) error
+	ResolveConfiguration(configItems config.ConfigurationSet) error
+	PopulateAccount(account *cfg.IDPAccount, configItems config.ConfigurationSet) error
 	ProcessAssertions(account *cfg.IDPAccount, samlAssertions string) (provider.Identity, error)
 }

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -19,8 +19,8 @@ package provider
 import (
 	"context"
 
+	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 type ContextOption func(*Context)
@@ -29,23 +29,20 @@ type ContextOption func(*Context)
 type Context struct {
 	context.Context
 
-	command *cobra.Command
-	logger  *logrus.Entry
-
+	logger      *logrus.Entry
 	interactive bool
-
-	//ClusterProvider ClusterProvider
+	cfgItems    config.ConfigurationSet
 }
 
 // NewContext creates a new context
-func NewContext(cmd *cobra.Command, opts ...ContextOption) *Context {
+func NewContext(opts ...ContextOption) *Context {
 	defaultContext := context.Background()
 
 	c := &Context{
 		Context:     defaultContext,
-		command:     cmd,
 		logger:      logrus.StandardLogger().WithContext(defaultContext),
 		interactive: true,
+		cfgItems:    config.NewConfigurationSet(),
 	}
 
 	for _, opt := range opts {
@@ -61,12 +58,6 @@ func WithContext(ctx context.Context) ContextOption {
 	}
 }
 
-// func WithClusterProvider(provider ClusterProvider) ContextOption {
-// 	return func(c *Context) {
-// 		c.ClusterProvider = provider
-// 	}
-// }
-
 func WithLogger(logger *logrus.Entry) ContextOption {
 	return func(c *Context) {
 		c.logger = logger
@@ -79,8 +70,10 @@ func WithInteractive(interactive bool) ContextOption {
 	}
 }
 
-func (c *Context) Command() *cobra.Command {
-	return c.command
+func WithConfig(cs config.ConfigurationSet) ContextOption {
+	return func(c *Context) {
+		c.cfgItems = cs
+	}
 }
 
 func (c *Context) Logger() *logrus.Entry {
@@ -89,4 +82,8 @@ func (c *Context) Logger() *logrus.Entry {
 
 func (c *Context) IsInteractive() bool {
 	return c.interactive
+}
+
+func (c *Context) ConfigurationItems() config.ConfigurationSet {
+	return c.cfgItems
 }

--- a/pkg/provider/registry.go
+++ b/pkg/provider/registry.go
@@ -23,12 +23,14 @@ import (
 )
 
 var (
+	ErrDuplicatePlugin = errors.New("plugin already registered with same name")
+	ErrPluginNotFound  = errors.New("plugin not found")
+)
+
+var (
 	pluginsLock     sync.Mutex
 	identityPlugins = make(map[string]IdentityProvider)
 	clusterPlugins  = make(map[string]ClusterProvider)
-
-	ErrDuplicatePlugin = errors.New("plugin already registered with same name")
-	ErrPluginNotFound  = errors.New("plugin not found")
 )
 
 func RegisterIdentityProviderPlugin(name string, plugin IdentityProvider) error {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package provider
 
 import (
-	"github.com/spf13/pflag"
+	"github.com/fidelity/kconnect/pkg/config"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -35,24 +35,22 @@ type ClusterProvider interface {
 
 	GetClusterConfig(ctx *Context, cluster *Cluster, setCurrent bool) (*api.Config, error)
 
-	// FlagsResolver returns the resolver used to inetractively resolve flags
-	FlagsResolver() FlagsResolver
+	// ConfigurationResolver returns the resolver used to interactively resolve configuration
+	ConfigurationResolver() ConfigResolver
 }
 
-// FlagsResolver is used to resolve the values for flags interactively.
-// There will be a flags resolver for Azure, AWS and Rancher initially.
-type FlagsResolver interface {
+// ConfigResolver is used to resolve the values for config items interactively.
+type ConfigResolver interface {
 
-	// Validate is used to validate the flags and return any errors
-	Validate(ctx *Context, flags *pflag.FlagSet) error
+	// Validate is used to validate the config items and return any errors
+	Validate(config config.ConfigurationSet) error
 
-	// Resolve will resolve the values for the supplied context. It will interactively
-	// resolve the values by asking the user for selections. It will basically set the
-	// Value on each pflag.Flag
-	Resolve(ctx *Context, flags *pflag.FlagSet) error
+	// Resolve will resolve the values for the supplied config items. It will interactively
+	// resolve the values by asking the user for selections.
+	Resolve(config config.ConfigurationSet) error
 }
 
-type FlagResolveFunc func(name string, flags *pflag.FlagSet) error
+type ConfigResolveFunc func(name string, config *config.ConfigurationSet) error
 
 // IdentityProvider represents the interface used to implement an identity provider
 // plugin. It provides authentication and authorization functionality.
@@ -98,8 +96,8 @@ type Plugin interface {
 	// Name returns the name of the plugin
 	Name() string
 
-	// Flags will return the flags as part of a flagset for the plugin
-	Flags() *pflag.FlagSet
+	// ConfigurationItems will return the configuration items for the plugin
+	ConfigurationItems() config.ConfigurationSet
 
 	// Usage returns a string to display for help
 	Usage() string


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed flags/flagset from leaking through into the providers. Replaced with teh concept of config items and config sets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #