### PR TITLE
fix: kubeconfig merge and duplicate history entries

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -119,6 +119,7 @@ func (in *ConfigurationSpec) DeepCopy() *ConfigurationSpec {
 func (in *HistoryEntry) DeepCopyInto(out *HistoryEntry) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 }

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kubectl v0.19.1
 	sigs.k8s.io/structured-merge-diff/v2 v2.0.1 // indirect
+	sigs.k8s.io/yaml v1.2.0
 
 )
 

--- a/internal/app/use.go
+++ b/internal/app/use.go
@@ -72,7 +72,7 @@ func (a *App) Use(params *UseParams) error {
 		return nil
 	}
 
-	kubeConfig, contextName, err := clusterProvider.GetClusterConfig(params.Context, cluster, params.SetCurrent)
+	kubeConfig, contextName, err := clusterProvider.GetClusterConfig(params.Context, cluster)
 	if err != nil {
 		return fmt.Errorf("creating kubeconfig for %s: %w", cluster.Name, err)
 	}
@@ -90,12 +90,12 @@ func (a *App) Use(params *UseParams) error {
 			return fmt.Errorf("adding connection to history: %w", err)
 		}
 
-		historyRef := historyv1alpha.NewHistoryReference(entry.Spec.ID)
+		historyRef := historyv1alpha.NewHistoryReference(entry.ObjectMeta.Name)
 		kubeConfig.Contexts[contextName].Extensions = make(map[string]runtime.Object)
 		kubeConfig.Contexts[contextName].Extensions["kconnect"] = historyRef
 	}
 
-	if err := kubeconfig.Write(params.Kubeconfig, kubeConfig); err != nil {
+	if err := kubeconfig.Write(params.Kubeconfig, kubeConfig, params.SetCurrent); err != nil {
 		return fmt.Errorf("writing cluster kubeconfig: %w", err)
 	}
 

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -24,11 +24,11 @@ func AppDirectory() string {
 func HistoryPath() string {
 	appDir := AppDirectory()
 
-	return path.Join(appDir, "history")
+	return path.Join(appDir, "history.yaml")
 }
 
 func ConfigPath() string {
 	appDir := AppDirectory()
 
-	return path.Join(appDir, "config")
+	return path.Join(appDir, "config.yaml")
 }

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,6 +24,7 @@ import (
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 
 	kconnectv1alpha "github.com/fidelity/kconnect/api/v1alpha1"
 	"github.com/fidelity/kconnect/internal/defaults"
@@ -95,7 +95,7 @@ func (a *appConfiguration) Get() (*kconnectv1alpha.Configuration, error) {
 }
 
 func (a *appConfiguration) Save(configuration *kconnectv1alpha.Configuration) error {
-	data, err := json.Marshal(configuration)
+	data, err := yaml.Marshal(configuration)
 	if err != nil {
 		return fmt.Errorf("marshalling configuration: %w", err)
 	}

--- a/pkg/history/filter.go
+++ b/pkg/history/filter.go
@@ -89,7 +89,7 @@ func ByHistoryID(spec *FilterSpec, entry *historyv1alpha.HistoryEntry) bool {
 		return true
 	}
 
-	return entry.Spec.ID == *spec.HistoryID
+	return entry.ObjectMeta.Name == *spec.HistoryID
 }
 
 func ByProviderID(spec *FilterSpec, entry *historyv1alpha.HistoryEntry) bool {

--- a/pkg/history/loader/loader.go
+++ b/pkg/history/loader/loader.go
@@ -17,11 +17,12 @@ limitations under the License.
 package loader
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"sigs.k8s.io/yaml"
 
 	historyv1alpha "github.com/fidelity/kconnect/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,7 +88,7 @@ func (f *fileLoader) Load() (*historyv1alpha.HistoryEntryList, error) {
 }
 
 func (f *fileLoader) Save(historyList *historyv1alpha.HistoryEntryList) error {
-	data, err := json.Marshal(historyList)
+	data, err := yaml.Marshal(historyList)
 	if err != nil {
 		return fmt.Errorf("marshalling history list: %w", err)
 	}

--- a/pkg/k8s/kubeconfig/kubeconfig.go
+++ b/pkg/k8s/kubeconfig/kubeconfig.go
@@ -19,7 +19,6 @@ package kubeconfig
 import (
 	"fmt"
 
-	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -32,8 +31,8 @@ var (
 
 // Write will write the kubeconfig to the specified file. If there
 // is an existing kubeconfig it will be merged
-func Write(path string, clusterConfig *api.Config) error {
-	logger.Infof("Writing kubeconfig to %s", path)
+func Write(path string, clusterConfig *api.Config, setCurrent bool) error {
+	logger.Debugf("writing kubeconfig: %s", path)
 
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	if path != "" {
@@ -45,13 +44,26 @@ func Write(path string, clusterConfig *api.Config) error {
 		return fmt.Errorf("getting existing kubeconfig: %w", err)
 	}
 
-	if err := mergo.Merge(existingConfig, clusterConfig); err != nil {
-		return fmt.Errorf("merging cluster config: %w", err)
+	logger.Debug("merging kubeconfig files")
+	for k, v := range clusterConfig.Clusters {
+		existingConfig.Clusters[k] = v
+	}
+	for k, v := range clusterConfig.AuthInfos {
+		existingConfig.AuthInfos[k] = v
+	}
+	for k, v := range clusterConfig.Contexts {
+		existingConfig.Contexts[k] = v
+	}
+
+	if setCurrent {
+		logger.Infof("setting current context to: %s", clusterConfig.CurrentContext)
+		existingConfig.CurrentContext = clusterConfig.CurrentContext
 	}
 
 	if err := clientcmd.ModifyConfig(pathOptions, *existingConfig, true); err != nil {
 		return fmt.Errorf("writing kubeconfig: %w", err)
 	}
+	logger.Infof("kubeconfig updated: %s", path)
 
 	return nil
 }

--- a/pkg/plugins/discovery/aws/config.go
+++ b/pkg/plugins/discovery/aws/config.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/provider"
 )
 
-func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster, setCurrent bool) (*api.Config, string, error) {
+func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster) (*api.Config, string, error) {
 	clusterName := fmt.Sprintf("kconnect-eks-%s", cluster.Name)
 	userName := fmt.Sprintf("kconnect-%s-%s", p.identity.ProfileName, cluster.Name)
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
@@ -72,10 +72,7 @@ func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *pr
 		},
 	}
 
-	if setCurrent {
-		p.logger.Infof("setting current context to: %s", contextName)
-		cfg.CurrentContext = contextName
-	}
+	cfg.CurrentContext = contextName
 
 	return cfg, contextName, nil
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -38,7 +38,7 @@ type ClusterProvider interface {
 	Get(ctx *Context, clusterID string, identity Identity) (*Cluster, error)
 
 	// GetClusterConfig will get the kubeconfig for a cluster
-	GetClusterConfig(ctx *Context, cluster *Cluster, setCurrent bool) (*api.Config, string, error)
+	GetClusterConfig(ctx *Context, cluster *Cluster) (*api.Config, string, error)
 
 	// ConfigurationResolver returns the resolver used to interactively resolve configuration
 	ConfigurationResolver() ConfigResolver


### PR DESCRIPTION
**What this PR does / why we need it**:
Merging of the kubeconfig was failing when the cluster connected to was the same as the previous usage. Additionally duplicate history entries where written for the same connection.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
Fixes #90 
Fixes #89 