### PR TITLE
feat: add deb and rpm packaging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,25 @@ dockers:
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
 
+nfpms:
+  -
+    package_name: kconnect
+    replacements:
+      darwin: macos
+      amd64: 64-bit
+    vendor: kconnect authors
+    homepage: https://github.com/fidelity/kconnect
+    description: "The Kubernetes Connection Manager CLI"
+    license: Apache 2.0
+    formats:
+      - apk
+      - deb
+      - rpm
+    dependencies:
+      - kubectl
+
+
+
 
 # snapcrafts:
 #   -


### PR DESCRIPTION
**What this PR does / why we need it**:
Make kconnect available as a .deb or .rpm download for use on linux.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62 