### PR TITLE
fix: set current context when using 'to'

### DIFF
--- a/internal/app/to.go
+++ b/internal/app/to.go
@@ -30,8 +30,9 @@ type ConnectToParams struct {
 	HistoryConfig
 	KubernetesConfig
 
-	AliasOrID string
-	Password  string `json:"password"`
+	AliasOrID  string
+	Password   string `json:"password"`
+	SetCurrent bool   `json:"set-current,omitempty"`
 
 	Context *provider.Context
 }
@@ -81,6 +82,7 @@ func (a *App) ConnectTo(params *ConnectToParams) error {
 
 	useParams.NoHistory = true
 	useParams.ClusterID = &entry.Spec.ProviderID
+	useParams.SetCurrent = params.SetCurrent
 
 	identity, err := useParams.IdentityProvider.Authenticate(useParams.Context, useParams.Provider.Name())
 	if err != nil {
@@ -125,6 +127,9 @@ func (a *App) buildConnectToConfig(idProvider provider.IdentityProvider, cluster
 	if err := AddKubeconfigConfigItems(cs); err != nil {
 		return nil, fmt.Errorf("adding kubeconfig config items: %w", err)
 	}
+	if err := AddCommonConfigItems(cs); err != nil {
+		return nil, fmt.Errorf("adding common config items: %w", err)
+	}
 
 	for k, v := range historyEntry.Spec.Flags {
 		configItem := cs.Get(k)
@@ -150,6 +155,12 @@ func (a *App) buildConnectToConfig(idProvider provider.IdentityProvider, cluster
 			configItem.Value = boolVal
 		default:
 			return nil, fmt.Errorf("trying to set config item %s of type %s: %w", configItem.Name, configItem.Type, ErrUnknownConfigItemType)
+		}
+	}
+
+	for _, configItem := range cs.GetAll() {
+		if !configItem.HasValue() {
+			configItem.Value = configItem.DefaultValue
 		}
 	}
 

--- a/internal/commands/configure/configure.go
+++ b/internal/commands/configure/configure.go
@@ -39,7 +39,7 @@ func Command() (*cobra.Command, error) {
 			params := &app.ConfigureInput{}
 
 			flags.BindFlags(cmd)
-			flags.PopulateConfigFromFlags(cmd.Flags(), cfg)
+			flags.PopulateConfigFromCommand(cmd, cfg)
 			if err := config.Unmarshall(cfg, params); err != nil {
 				return fmt.Errorf("unmarshalling config into to params: %w", err)
 			}
@@ -59,7 +59,7 @@ func Command() (*cobra.Command, error) {
 		return nil, fmt.Errorf("add command config: %w", err)
 	}
 
-	if err := flags.CreateFlagsAndMarkRequired(cfgCmd, cfg); err != nil {
+	if err := flags.CreateCommandFlags(cfgCmd, cfg); err != nil {
 		return nil, err
 	}
 
@@ -68,6 +68,9 @@ func Command() (*cobra.Command, error) {
 }
 
 func addConfig(cs config.ConfigurationSet) error {
+	if err := app.AddCommonConfigItems(cs); err != nil {
+		return fmt.Errorf("adding common config: %w", err)
+	}
 	if _, err := cs.String("file", "", "File or remote location to use to set the default configuration"); err != nil {
 		return fmt.Errorf("adding file config item: %w", err)
 	}

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -41,7 +41,7 @@ func Command() (*cobra.Command, error) {
 			params := &app.HistoryQueryInput{}
 
 			flags.BindFlags(cmd)
-			flags.PopulateConfigFromFlags(cmd.Flags(), cfg)
+			flags.PopulateConfigFromCommand(cmd, cfg)
 			if err := config.ApplyToConfigSet(cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
@@ -73,7 +73,7 @@ func Command() (*cobra.Command, error) {
 		return nil, fmt.Errorf("add command config: %w", err)
 	}
 
-	if err := flags.CreateFlagsAndMarkRequired(lsCmd, cfg); err != nil {
+	if err := flags.CreateCommandFlags(lsCmd, cfg); err != nil {
 		return nil, err
 	}
 
@@ -82,6 +82,9 @@ func Command() (*cobra.Command, error) {
 }
 
 func addConfig(cs config.ConfigurationSet) error {
+	if err := app.AddCommonConfigItems(cs); err != nil {
+		return fmt.Errorf("adding common config: %w", err)
+	}
 	if err := app.AddHistoryQueryConfig(cs); err != nil {
 		return fmt.Errorf("adding history query config items: %w", err)
 	}

--- a/internal/commands/to/to.go
+++ b/internal/commands/to/to.go
@@ -51,13 +51,14 @@ You can use the history id or alias as the argument.`,
 			if len(args) < 1 {
 				return ErrAliasIDRequired
 			}
+			params.AliasOrID = args[0]
 
 			flags.BindFlags(cmd)
-			flags.PopulateConfigFromFlags(cmd.Flags(), params.Context.ConfigurationItems())
+			flags.PopulateConfigFromCommand(cmd, params.Context.ConfigurationItems())
+
 			if err := config.Unmarshall(params.Context.ConfigurationItems(), params); err != nil {
 				return fmt.Errorf("unmarshalling config into to params: %w", err)
 			}
-			params.AliasOrID = args[0]
 
 			params.Context = provider.NewContext(
 				provider.WithLogger(logger),
@@ -86,7 +87,7 @@ You can use the history id or alias as the argument.`,
 		return nil, fmt.Errorf("add command config: %w", err)
 	}
 
-	if err := flags.CreateFlagsAndMarkRequired(toCmd, params.Context.ConfigurationItems()); err != nil {
+	if err := flags.CreateCommandFlags(toCmd, params.Context.ConfigurationItems()); err != nil {
 		return nil, err
 	}
 
@@ -94,6 +95,12 @@ You can use the history id or alias as the argument.`,
 }
 
 func addConfig(cs config.ConfigurationSet) error {
+	if err := app.AddCommonConfigItems(cs); err != nil {
+		return fmt.Errorf("adding common config: %w", err)
+	}
+	if _, err := cs.Bool("set-current", true, "Sets the current context in the kubeconfig to the selected cluster"); err != nil {
+		return fmt.Errorf("adding set-current config: %w", err)
+	}
 	if _, err := cs.String("password", "", "Password to use"); err != nil {
 		return fmt.Errorf("adding password config: %w", err)
 	}

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -76,7 +76,7 @@ func createProviderCmd(clusterProvider provider.ClusterProvider) (*cobra.Command
 		Short: fmt.Sprintf("Connect to %s and discover clusters for use", clusterProvider.Name()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
-			flags.PopulateConfigFromFlags(cmd.Flags(), params.Context.ConfigurationItems())
+			flags.PopulateConfigFromCommand(cmd, params.Context.ConfigurationItems())
 			if err := config.ApplyToConfigSetWithProvider(params.Context.ConfigurationItems(), clusterProvider.Name()); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
@@ -119,7 +119,7 @@ func createProviderCmd(clusterProvider provider.ClusterProvider) (*cobra.Command
 		return nil, fmt.Errorf("additional command setup: %w", err)
 	}
 
-	if err := flags.CreateFlagsAndMarkRequired(providerCmd, params.Context.ConfigurationItems()); err != nil {
+	if err := flags.CreateCommandFlags(providerCmd, params.Context.ConfigurationItems()); err != nil {
 		return nil, err
 	}
 
@@ -127,6 +127,9 @@ func createProviderCmd(clusterProvider provider.ClusterProvider) (*cobra.Command
 }
 
 func addConfig(cs config.ConfigurationSet, clusterProvider provider.ClusterProvider) error {
+	if err := app.AddCommonConfigItems(cs); err != nil {
+		return fmt.Errorf("adding common config %s: %w", clusterProvider.Name(), err)
+	}
 	if err := cs.AddSet(clusterProvider.ConfigurationItems()); err != nil {
 		return fmt.Errorf("adding cluster provider config %s: %w", clusterProvider.Name(), err)
 	}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -50,16 +50,12 @@ func ExistsWithValue(name string, flags *pflag.FlagSet) bool {
 	return true
 }
 
-func CreateFlagsAndMarkRequired(cmd *cobra.Command, cs config.ConfigurationSet) error {
+func CreateCommandFlags(cmd *cobra.Command, cs config.ConfigurationSet) error {
 	flags, err := CreateFlagsFromConfig(cs)
 	if err != nil {
 		return fmt.Errorf("creating flags from config set: %w", err)
 	}
 	cmd.Flags().AddFlagSet(flags)
-
-	if err := MarkRequired(cmd, cs); err != nil {
-		return fmt.Errorf("marking flags required: %w", err)
-	}
 
 	return nil
 }
@@ -99,17 +95,17 @@ func CreateFlagsFromConfig(cs config.ConfigurationSet) (*pflag.FlagSet, error) {
 	return fs, nil
 }
 
-func MarkRequired(cmd *cobra.Command, cs config.ConfigurationSet) error {
-	for _, configItem := range cs.GetAll() {
-		if configItem.Required {
-			if err := cmd.MarkFlagRequired(configItem.Name); err != nil {
-				return fmt.Errorf("marking flag required %s: %w", configItem.Name, err)
-			}
-		}
-	}
+// func MarkRequired(cmd *cobra.Command, cs config.ConfigurationSet) error {
+// 	for _, configItem := range cs.GetAll() {
+// 		if configItem.Required {
+// 			if err := cmd.MarkFlagRequired(configItem.Name); err != nil {
+// 				return fmt.Errorf("marking flag required %s: %w", configItem.Name, err)
+// 			}
+// 		}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 func PopulateConfigFromFlags(flags *pflag.FlagSet, cs config.ConfigurationSet) {
 	flags.VisitAll(func(f *pflag.Flag) {

--- a/pkg/provider/config.go
+++ b/pkg/provider/config.go
@@ -46,9 +46,6 @@ func AddCommonClusterConfig(cs config.ConfigurationSet) error {
 	if _, err := cs.String("cluster-id", "", "Id of the cluster to use."); err != nil {
 		return fmt.Errorf("adding cluster-id setting: %w", err)
 	}
-	if _, err := cs.Bool("non-interactive", false, "Run without interactive flag resolution"); err != nil {
-		return fmt.Errorf("adding non-interactive setting: %w", err)
-	}
 	if _, err := cs.String("alias", "", "Friendly name to give to give the connection"); err != nil {
 		return fmt.Errorf("adding alias setting: %w", err)
 	}
@@ -58,6 +55,9 @@ func AddCommonClusterConfig(cs config.ConfigurationSet) error {
 	}
 	if err := cs.SetShort("alias", "a"); err != nil {
 		return fmt.Errorf("setting shorthand for alias setting: %w", err)
+	}
+	if err := cs.SetSensitive("alias"); err != nil {
+		return fmt.Errorf("setting alias as sensitive: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed to propogate setting the current context when using the
`to` command to connect to a previously connected cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #109 