### PR TITLE
Set history on use

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -32,8 +32,9 @@ type HistoryLocationConfig struct {
 
 type HistoryConfig struct {
 	HistoryLocationConfig
-	MaxItems  int  `json:"max-history"`
-	NoHistory bool `json:"no-history"`
+	MaxItems  int    `json:"max-history"`
+	NoHistory bool   `json:"no-history"`
+	EntryID   string `json:"entry-id"`
 }
 
 func AddHistoryLocationItems(cs config.ConfigurationSet) error {
@@ -54,6 +55,13 @@ func AddHistoryConfigItems(cs config.ConfigurationSet) error {
 	}
 	if _, err := cs.Bool("no-history", false, "If set to true then no history entry will be written"); err != nil {
 		return fmt.Errorf("adding no-history config: %w", err)
+	}
+	if _, err := cs.String("entry-id", "", "existing entry id."); err != nil {
+		return fmt.Errorf("adding entry-id config: %w", err)
+	}
+
+	if err := cs.SetHidden("entry-id"); err != nil {
+		return fmt.Errorf("setting entry-id hidden: %w", err)
 	}
 
 	return nil

--- a/internal/app/to.go
+++ b/internal/app/to.go
@@ -44,6 +44,7 @@ func (a *App) ConnectTo(params *ConnectToParams) error {
 	if err != nil {
 		return fmt.Errorf("getting history entry: %w", err)
 	}
+	historyID := entry.ObjectMeta.Name
 
 	idProvider, err := provider.GetIdentityProvider(entry.Spec.Identity)
 	if err != nil {
@@ -81,6 +82,7 @@ func (a *App) ConnectTo(params *ConnectToParams) error {
 	}
 
 	useParams.NoHistory = true
+	useParams.EntryID = historyID
 	useParams.ClusterID = &entry.Spec.ProviderID
 	useParams.SetCurrent = params.SetCurrent
 

--- a/internal/app/use.go
+++ b/internal/app/use.go
@@ -77,6 +77,7 @@ func (a *App) Use(params *UseParams) error {
 		return fmt.Errorf("creating kubeconfig for %s: %w", cluster.Name, err)
 	}
 
+	historyID := params.EntryID
 	if !params.NoHistory {
 		entry := historyv1alpha.NewHistoryEntry()
 		entry.Spec.Alias = params.Alias
@@ -90,7 +91,11 @@ func (a *App) Use(params *UseParams) error {
 			return fmt.Errorf("adding connection to history: %w", err)
 		}
 
-		historyRef := historyv1alpha.NewHistoryReference(entry.ObjectMeta.Name)
+		historyID = entry.ObjectMeta.Name
+	}
+
+	if historyID != "" {
+		historyRef := historyv1alpha.NewHistoryReference(historyID)
 		kubeConfig.Contexts[contextName].Extensions = make(map[string]runtime.Object)
 		kubeConfig.Contexts[contextName].Extensions["kconnect"] = historyRef
 	}

--- a/pkg/config/configset.go
+++ b/pkg/config/configset.go
@@ -26,15 +26,18 @@ var (
 
 // Item represents a configuration item
 type Item struct {
-	Name             string
-	Shorthand        string
-	Type             ItemType
-	Sensitive        bool
-	Description      string
-	ResolutionPrompt string
-	Value            interface{}
-	DefaultValue     interface{}
-	Required         bool
+	Name              string
+	Shorthand         string
+	Type              ItemType
+	Sensitive         bool
+	Description       string
+	ResolutionPrompt  string
+	Value             interface{}
+	DefaultValue      interface{}
+	Required          bool
+	Hidden            bool
+	Deprecated        bool
+	DeprecatedMessage string
 }
 
 func (i *Item) HasValue() bool {
@@ -70,6 +73,8 @@ type ConfigurationSet interface {
 	AddSet(set ConfigurationSet) error
 	SetSensitive(name string) error
 	SetRequired(name string) error
+	SetHidden(name string) error
+	SetDeprecated(name string, message string) error
 	SetValue(name string, value interface{}) error
 	SetShort(name string, shorthand string) error
 
@@ -158,6 +163,29 @@ func (s *configSet) SetRequired(name string) error {
 	}
 
 	item.Required = true
+
+	return nil
+}
+
+func (s *configSet) SetHidden(name string) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.Hidden = true
+
+	return nil
+}
+
+func (s *configSet) SetDeprecated(name string, message string) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.Deprecated = true
+	item.DeprecatedMessage = message
 
 	return nil
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -90,22 +90,21 @@ func CreateFlagsFromConfig(cs config.ConfigurationSet) (*pflag.FlagSet, error) {
 		default:
 			return nil, config.ErrUnknownItemType
 		}
+
+		if configItem.Deprecated {
+			if err := fs.MarkDeprecated(configItem.Name, configItem.DeprecatedMessage); err != nil {
+				return nil, fmt.Errorf("marking flag deprecated %s: %w", configItem.Name, err)
+			}
+		}
+		if configItem.Hidden {
+			if err := fs.MarkHidden(configItem.Name); err != nil {
+				return nil, fmt.Errorf("marking flag hidden %s: %w", configItem.Name, err)
+			}
+		}
 	}
 
 	return fs, nil
 }
-
-// func MarkRequired(cmd *cobra.Command, cs config.ConfigurationSet) error {
-// 	for _, configItem := range cs.GetAll() {
-// 		if configItem.Required {
-// 			if err := cmd.MarkFlagRequired(configItem.Name); err != nil {
-// 				return fmt.Errorf("marking flag required %s: %w", configItem.Name, err)
-// 			}
-// 		}
-// 	}
-
-// 	return nil
-// }
 
 func PopulateConfigFromFlags(flags *pflag.FlagSet, cs config.ConfigurationSet) {
 	flags.VisitAll(func(f *pflag.Flag) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The history extension is not being set when using `kconnect use`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #118 