### PR TITLE
refactor: changed the logging in the commands 

### DIFF
--- a/internal/commands/configure/configure.go
+++ b/internal/commands/configure/configure.go
@@ -28,18 +28,26 @@ import (
 )
 
 func Command() (*cobra.Command, error) {
-	logger := logrus.New().WithField("command", "configure")
-
 	cfg := config.NewConfigurationSet()
 
 	cfgCmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Set and view your default kconnect configuration. If no flags are supplied your config is displayed.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			params := &app.ConfigureInput{}
-
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
+
+			if err := config.ApplyToConfigSet(cfg); err != nil {
+				return fmt.Errorf("applying app config: %w", err)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := logrus.New().WithField("command", "configure")
+
+			params := &app.ConfigureInput{}
+
 			if err := config.Unmarshall(cfg, params); err != nil {
 				return fmt.Errorf("unmarshalling config into to params: %w", err)
 			}

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -30,21 +30,25 @@ import (
 )
 
 func Command() (*cobra.Command, error) {
-	logger := logrus.New().WithField("command", "ls")
-
 	cfg := config.NewConfigurationSet()
 
 	lsCmd := &cobra.Command{
 		Use:   "ls",
 		Short: "Query your connection history",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			params := &app.HistoryQueryInput{}
-
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
+
 			if err := config.ApplyToConfigSet(cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := logrus.New().WithField("command", "ls")
+			params := &app.HistoryQueryInput{}
+
 			if err := config.Unmarshall(cfg, params); err != nil {
 				return fmt.Errorf("unmarshalling config into to params: %w", err)
 			}

--- a/internal/commands/to/to.go
+++ b/internal/commands/to/to.go
@@ -35,11 +35,7 @@ var (
 )
 
 func Command() (*cobra.Command, error) {
-	logger := logrus.New().WithField("command", "to")
-
-	params := &app.ConnectToParams{
-		Context: provider.NewContext(provider.WithLogger(logger)),
-	}
+	cfg := config.NewConfigurationSet()
 
 	toCmd := &cobra.Command{
 		Use:   "to [historyid/alias]",
@@ -51,23 +47,24 @@ You can use the history id or alias as the argument.`,
 			if len(args) < 1 {
 				return ErrAliasIDRequired
 			}
-			params.AliasOrID = args[0]
 
 			flags.BindFlags(cmd)
-			flags.PopulateConfigFromCommand(cmd, params.Context.ConfigurationItems())
-
-			if err := config.Unmarshall(params.Context.ConfigurationItems(), params); err != nil {
-				return fmt.Errorf("unmarshalling config into to params: %w", err)
-			}
-
-			params.Context = provider.NewContext(
-				provider.WithLogger(logger),
-				provider.WithConfig(params.Context.ConfigurationItems()),
-			)
+			flags.PopulateConfigFromCommand(cmd, cfg)
 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := logrus.New().WithField("command", "to")
+
+			params := &app.ConnectToParams{
+				Context:   provider.NewContext(provider.WithConfig(cfg), provider.WithLogger(logger)),
+				AliasOrID: args[0],
+			}
+
+			if err := config.Unmarshall(cfg, params); err != nil {
+				return fmt.Errorf("unmarshalling config into to params: %w", err)
+			}
+
 			historyLoader, err := loader.NewFileLoader(params.Location)
 			if err != nil {
 				return fmt.Errorf("getting history loader with path %s: %w", params.Location, err)
@@ -83,11 +80,11 @@ You can use the history id or alias as the argument.`,
 		},
 	}
 
-	if err := addConfig(params.Context.ConfigurationItems()); err != nil {
+	if err := addConfig(cfg); err != nil {
 		return nil, fmt.Errorf("add command config: %w", err)
 	}
 
-	if err := flags.CreateCommandFlags(toCmd, params.Context.ConfigurationItems()); err != nil {
+	if err := flags.CreateCommandFlags(toCmd, cfg); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The logging has been changed in the commands so that the logger is created at execution of the command and not when the command is created. This is to make sure the log level is respected.

We need to rethink logging as part of #119 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #