### PR TITLE
feat: alias and username in table output

### DIFF
--- a/api/v1alpha1/history_types.go
+++ b/api/v1alpha1/history_types.go
@@ -149,6 +149,10 @@ func (l *HistoryEntryList) ToTable() *metav1.Table {
 				Type: "string",
 			},
 			{
+				Name: "Alias",
+				Type: "string",
+			},
+			{
 				Name: "Provider",
 				Type: "string",
 			},
@@ -160,12 +164,24 @@ func (l *HistoryEntryList) ToTable() *metav1.Table {
 				Name: "Identity",
 				Type: "string",
 			},
+			{
+				Name: "User",
+				Type: "string",
+			},
 		},
 	}
 
 	for _, entry := range l.Items {
+		username := entry.Spec.Flags["username"]
+
 		row := metav1.TableRow{
-			Cells: []interface{}{entry.ObjectMeta.Name, entry.Spec.Provider, entry.Spec.ProviderID, entry.Spec.Identity},
+			Cells: []interface{}{
+				entry.ObjectMeta.Name,
+				*entry.Spec.Alias,
+				entry.Spec.Provider,
+				entry.Spec.ProviderID,
+				entry.Spec.Identity,
+				username},
 		}
 		table.Rows = append(table.Rows, row)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The history table output now includes the username and alias

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #103 