### PR TITLE
feat: set namespace in kubeconfig

### DIFF
--- a/internal/app/use.go
+++ b/internal/app/use.go
@@ -43,6 +43,8 @@ type UseParams struct {
 	Identity         provider.Identity
 
 	Context *provider.Context
+
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (a *App) Use(params *UseParams) error {
@@ -72,7 +74,7 @@ func (a *App) Use(params *UseParams) error {
 		return nil
 	}
 
-	kubeConfig, contextName, err := clusterProvider.GetClusterConfig(params.Context, cluster)
+	kubeConfig, contextName, err := clusterProvider.GetClusterConfig(params.Context, cluster, params.Namespace)
 	if err != nil {
 		return fmt.Errorf("creating kubeconfig for %s: %w", cluster.Name, err)
 	}

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -153,6 +153,9 @@ func addConfig(cs config.ConfigurationSet, clusterProvider provider.ClusterProvi
 	if err := app.AddKubeconfigConfigItems(cs); err != nil {
 		return fmt.Errorf("adding kubeconfig config items: %w", err)
 	}
+	if _, err := cs.String("namespace", "default", "Sets namespace for context in kubeconfig"); err != nil {
+		return fmt.Errorf("setting namespace in kubeconfig: %w", err)
+	}
 
 	cs.SetHistoryIgnore("set-current") //nolint
 

--- a/pkg/plugins/discovery/aws/config.go
+++ b/pkg/plugins/discovery/aws/config.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/provider"
 )
 
-func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster) (*api.Config, string, error) {
+func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster, namespace string) (*api.Config, string, error) {
 	clusterName := fmt.Sprintf("kconnect-eks-%s", cluster.Name)
 	userName := fmt.Sprintf("kconnect-%s-%s", p.identity.ProfileName, cluster.Name)
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
@@ -44,8 +44,9 @@ func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *pr
 		},
 		Contexts: map[string]*api.Context{
 			contextName: {
-				Cluster:  clusterName,
-				AuthInfo: userName,
+				Namespace: namespace,
+				Cluster:   clusterName,
+				AuthInfo:  userName,
 			},
 		},
 	}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -38,7 +38,7 @@ type ClusterProvider interface {
 	Get(ctx *Context, clusterID string, identity Identity) (*Cluster, error)
 
 	// GetClusterConfig will get the kubeconfig for a cluster
-	GetClusterConfig(ctx *Context, cluster *Cluster) (*api.Config, string, error)
+	GetClusterConfig(ctx *Context, cluster *Cluster, namespace string) (*api.Config, string, error)
 
 	// ConfigurationResolver returns the resolver used to interactively resolve configuration
 	ConfigurationResolver() ConfigResolver


### PR DESCRIPTION
**What this PR does / why we need it**:

Add namespace as a param to `use` command to set in current context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #104