### PR TITLE
fix: removed re-using cached credentials

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -42,6 +42,8 @@ func AddHistoryLocationItems(cs config.ConfigurationSet) error {
 		return fmt.Errorf("adding history-location config: %w", err)
 	}
 
+	cs.SetHistoryIgnore("history-location") //nolint
+
 	return nil
 }
 
@@ -63,6 +65,10 @@ func AddHistoryConfigItems(cs config.ConfigurationSet) error {
 	if err := cs.SetHidden("entry-id"); err != nil {
 		return fmt.Errorf("setting entry-id hidden: %w", err)
 	}
+
+	cs.SetHistoryIgnore("max-history") //nolint
+	cs.SetHistoryIgnore("no-history")  //nolint
+	cs.SetHistoryIgnore("entry-id")    //nolint
 
 	return nil
 }
@@ -111,6 +117,11 @@ func AddCommonConfigItems(cs config.ConfigurationSet) error {
 		return fmt.Errorf("setting shorthand for log-level: %w", err)
 	}
 
+	cs.SetHistoryIgnore("config")          //nolint
+	cs.SetHistoryIgnore("log-level")       //nolint
+	cs.SetHistoryIgnore("log-format")      //nolint
+	cs.SetHistoryIgnore("non-interactive") //nolint
+
 	return nil
 }
 
@@ -121,6 +132,9 @@ func AddHistoryIdentifierConfig(cs config.ConfigurationSet) error {
 	if _, err := cs.String("id", "", "Id for a history entry"); err != nil {
 		return fmt.Errorf("adding id config: %w", err)
 	}
+
+	cs.SetHistoryIgnore("alias") //nolint
+	cs.SetHistoryIgnore("id")    //nolint
 
 	return nil
 }
@@ -139,6 +153,10 @@ func AddHistoryQueryConfig(cs config.ConfigurationSet) error {
 	if _, err := cs.String("provider-id", "", "Provider specific for a cluster"); err != nil {
 		return fmt.Errorf("adding provider-id config: %w", err)
 	}
+
+	cs.SetHistoryIgnore("cluster-provider")  //nolint
+	cs.SetHistoryIgnore("identity-provider") //nolint
+	cs.SetHistoryIgnore("provider-id")       //nolint
 
 	return nil
 

--- a/internal/app/use.go
+++ b/internal/app/use.go
@@ -147,20 +147,13 @@ func (a *App) getCluster(params *UseParams) (*provider.Cluster, error) {
 func (a *App) filterConfig(params *UseParams) map[string]string {
 	filteredConfig := make(map[string]string)
 
-	idConfigSet := params.IdentityProvider.ConfigurationItems()
-	discConfigSet := params.Provider.ConfigurationItems()
-	commonIDConfigSet := provider.CommonIdentityConfig()
-
 	for _, configItem := range params.Context.ConfigurationItems().GetAll() {
-		cmnConfig := commonIDConfigSet.Get(configItem.Name)
-		idConfig := idConfigSet.Get(configItem.Name)
-		discConfig := discConfigSet.Get(configItem.Name)
 
-		if cmnConfig == nil && idConfig == nil && discConfig == nil {
+		if configItem.Sensitive {
 			continue
 		}
 
-		if configItem.Sensitive {
+		if configItem.HistoryIgnore {
 			continue
 		}
 

--- a/internal/commands/configure/configure.go
+++ b/internal/commands/configure/configure.go
@@ -89,5 +89,8 @@ func addConfig(cs config.ConfigurationSet) error {
 		return fmt.Errorf("setting shorthand for file config item: %w", err)
 	}
 
+	cs.SetHistoryIgnore("file")   //nolint
+	cs.SetHistoryIgnore("output") //nolint
+
 	return nil
 }

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -102,5 +102,7 @@ func addConfig(cs config.ConfigurationSet) error {
 		return fmt.Errorf("adding output config item: %w", err)
 	}
 
+	cs.SetHistoryIgnore("output") //nolint
+
 	return nil
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -101,7 +101,7 @@ func RootCmd() (*cobra.Command, error) {
 
 	cobra.OnInitialize(initConfig)
 
-	// Forge initial parsing of flags
+	// Force initial parsing of flags
 	rootCmd.FParseErrWhitelist = cobra.FParseErrWhitelist{
 		UnknownFlags: true,
 	}

--- a/internal/commands/to/to.go
+++ b/internal/commands/to/to.go
@@ -108,5 +108,8 @@ func addConfig(cs config.ConfigurationSet) error {
 		return fmt.Errorf("adding kubeconfig config items: %w", err)
 	}
 
+	cs.SetHistoryIgnore("password") //nolint
+	cs.SetSensitive("password")     //nolint
+
 	return nil
 }

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -154,6 +154,8 @@ func addConfig(cs config.ConfigurationSet, clusterProvider provider.ClusterProvi
 		return fmt.Errorf("adding kubeconfig config items: %w", err)
 	}
 
+	cs.SetHistoryIgnore("set-current") //nolint
+
 	return nil
 }
 

--- a/pkg/config/configset.go
+++ b/pkg/config/configset.go
@@ -29,8 +29,8 @@ type Item struct {
 	Name              string
 	Shorthand         string
 	Type              ItemType
-	Sensitive         bool
 	Description       string
+	Sensitive         bool
 	ResolutionPrompt  string
 	Value             interface{}
 	DefaultValue      interface{}
@@ -38,6 +38,7 @@ type Item struct {
 	Hidden            bool
 	Deprecated        bool
 	DeprecatedMessage string
+	HistoryIgnore     bool
 }
 
 func (i *Item) HasValue() bool {
@@ -72,6 +73,7 @@ type ConfigurationSet interface {
 	Add(item *Item) error
 	AddSet(set ConfigurationSet) error
 	SetSensitive(name string) error
+	SetHistoryIgnore(name string) error
 	SetRequired(name string) error
 	SetHidden(name string) error
 	SetDeprecated(name string, message string) error
@@ -152,6 +154,17 @@ func (s *configSet) SetSensitive(name string) error {
 	}
 
 	item.Sensitive = true
+
+	return nil
+}
+
+func (s *configSet) SetHistoryIgnore(name string) error {
+	item := s.Get(name)
+	if item == nil {
+		return ErrConfigNotFound
+	}
+
+	item.HistoryIgnore = true
 
 	return nil
 }

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -78,6 +78,8 @@ func (p *eksClusterProvider) ConfigurationItems() config.ConfigurationSet {
 	cs.SetRequired("region")    //nolint: errcheck
 	cs.SetRequired("partition") //nolint: errcheck
 
+	cs.SetHidden("profile") //nolint: errcheck
+
 	return cs
 }
 

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -94,7 +94,7 @@ func (p *ServiceProvider) PopulateAccount(account *cfg.IDPAccount, cfg config.Co
 	return nil
 }
 
-func (p *ServiceProvider) ProcessAssertions(account *cfg.IDPAccount, samlAssertions string) (provider.Identity, error) {
+func (p *ServiceProvider) ProcessAssertions(account *cfg.IDPAccount, samlAssertions string, cfg config.ConfigurationSet) (provider.Identity, error) {
 	data, err := base64.StdEncoding.DecodeString(samlAssertions)
 	if err != nil {
 		return nil, fmt.Errorf("decoding SAMLAssertion: %w", err)
@@ -119,7 +119,10 @@ func (p *ServiceProvider) ProcessAssertions(account *cfg.IDPAccount, samlAsserti
 		return nil, fmt.Errorf("resolving aws role: %w", err)
 	}
 
-	log.Printf("selected role: %s", role.RoleARN)
+	if err := cfg.SetValue("role-arn", role.RoleARN); err != nil {
+		return nil, fmt.Errorf("setting role-arn config value: %w", err)
+	}
+	p.logger.Debugf("selected role: %s", role.RoleARN)
 
 	awsCreds, err := p.loginToStsUsingRole(account, role, samlAssertions)
 	if err != nil {

--- a/pkg/plugins/identity/saml/sp/types.go
+++ b/pkg/plugins/identity/saml/sp/types.go
@@ -31,7 +31,7 @@ type ProviderConfig struct {
 
 type ServiceProvider interface {
 	Validate(configItems config.ConfigurationSet) error
-	ResolveConfiguration(configItems config.ConfigurationSet) error
+	ResolveConfiguration(configItems config.ConfigurationSet, interactive bool) error
 	PopulateAccount(account *cfg.IDPAccount, configItems config.ConfigurationSet) error
-	ProcessAssertions(account *cfg.IDPAccount, samlAssertions string) (provider.Identity, error)
+	ProcessAssertions(account *cfg.IDPAccount, samlAssertions string, configItems config.ConfigurationSet) (provider.Identity, error)
 }

--- a/pkg/provider/config.go
+++ b/pkg/provider/config.go
@@ -38,7 +38,6 @@ type ClusterProviderConfig struct {
 type IdentityProviderConfig struct {
 	Username    string `json:"username" validate:"required"`
 	Password    string `json:"password" validate:"required"`
-	Force       bool   `json:"force"`
 	IdpProtocol string `json:"idp-protocol" validate:"required"`
 }
 
@@ -60,6 +59,8 @@ func AddCommonClusterConfig(cs config.ConfigurationSet) error {
 		return fmt.Errorf("setting alias as sensitive: %w", err)
 	}
 
+	cs.SetHistoryIgnore("alias") //nolint
+
 	return nil
 }
 
@@ -77,11 +78,10 @@ func AddCommonIdentityConfig(cs config.ConfigurationSet) error {
 // CommonIdentityConfig creates a configset with the common identity config items
 func CommonIdentityConfig() config.ConfigurationSet {
 	cs := config.NewConfigurationSet()
-	cs.String("username", "", "the username used for authentication")                //nolint: errcheck
-	cs.String("password", "", "the password to use for authentication")              //nolint: errcheck
-	cs.Bool("force", false, "If true then we force authentication every invocation") //nolint: errcheck
-	cs.String("idp-protocol", "", "the idp protocol to use (e.g. saml)")             //nolint: errcheck
-	cs.SetSensitive("password")                                                      //nolint: errcheck
+	cs.String("username", "", "the username used for authentication")    //nolint: errcheck
+	cs.String("password", "", "the password to use for authentication")  //nolint: errcheck
+	cs.String("idp-protocol", "", "the idp protocol to use (e.g. saml)") //nolint: errcheck
+	cs.SetSensitive("password")                                          //nolint: errcheck
 
 	return cs
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The AWS profile name is now auto-created and this stops the sharing of credentials between subsequent calls to the kconnect which caused issues.

Also, changed how config values are persisted to history as role-arn wasn't being peristsed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #126 
Fixes #108 