### PR TITLE
fix: duplicate history entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ docs-build: docs-generate $(MDBOOK) ## Build the kconnect book
 .PHONY: docs-generate
 docs-generate: $(CMDDOCSGEN) ## Generate the cmd line docs
 	$(CMDDOCSGEN) $(BOOKS_DIR)/src/commands
+	rm -f $(TOOLS_BIN_DIR)/cmddocsgen
 
 .PHONY: docs-verify
 docs-verify: docs-generate ## Verify the generated docs are up to date

--- a/api/v1alpha1/history_types.go
+++ b/api/v1alpha1/history_types.go
@@ -79,12 +79,6 @@ type HistoryReference struct {
 	EntryID string
 }
 
-// var IgnoreFlagsInEquals = []string {
-// 	"profile",
-// 	"region-filter",
-// 	"role-filter",
-// }
-
 var ignoreFlags = map[string]struct{}{
 	"profile": {},
 }

--- a/api/v1alpha1/history_types_internal_test.go
+++ b/api/v1alpha1/history_types_internal_test.go
@@ -1,0 +1,180 @@
+package v1alpha1
+
+import "testing"
+
+func TestEquals(t *testing.T) {
+
+	testCases := []struct {
+		name   string
+		input1 *HistoryEntry
+		input2 *HistoryEntry
+		expect bool
+	}{
+		{
+			name:   "both nil history",
+			input1: nil,
+			input2: nil,
+			expect: true,
+		},
+		{
+			name:   "single nil history (1)",
+			input1: nil,
+			input2: &HistoryEntry{},
+			expect: false,
+		},
+		{
+			name:   "single nil history (2)",
+			input1: &HistoryEntry{},
+			input2: nil,
+			expect: false,
+		},
+		{
+			name: "unequals (provider)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "aks",
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "unequals (flags 1)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "",
+					},
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "namespace1",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "unequals (flags 2)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "namespace1",
+					},
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags:    map[string]string{},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "unequals (flags 3)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "namespace1",
+					},
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "namespace2",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "equals (flags 1)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "namespace1",
+					},
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace": "namespace1",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "equals (flags 2)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace":  "",
+						"region":     "us-east-1",
+						"kubeconfig": "",
+					},
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace":  "",
+						"region":     "us-east-1",
+						"cluster-id": "",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "equals (ignore flags)",
+			input1: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace":  "",
+						"region":     "us-east-1",
+						"kubeconfig": "",
+						"profile":    "profile1",
+					},
+				},
+			},
+			input2: &HistoryEntry{
+				Spec: HistoryEntrySpec{
+					Provider: "eks",
+					Flags: map[string]string{
+						"namespace":  "",
+						"region":     "us-east-1",
+						"cluster-id": "",
+						"profile":    "profile2",
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+	for _, tc := range testCases {
+		actualEqual := tc.input1.Equals(tc.input2)
+		if actualEqual != tc.expect {
+			t.Fatalf("expected %t, got %t", tc.expect, actualEqual)
+		}
+	}
+}

--- a/docs/book/src/commands/ls.md
+++ b/docs/book/src/commands/ls.md
@@ -39,7 +39,7 @@ kconnect ls [flags]
   -k, --kubeconfig string          Location of the kubeconfig to use. (default "$HOME/.kube/config")
       --max-history int            Sets the maximum number of history items to keep (default 100)
       --no-history                 If set to true then no history entry will be written
-      --output string              Output format for the results (default "table")
+  -o, --output string              Output format for the results (default "table")
       --provider-id string         Provider specific for a cluster
 ```
 

--- a/docs/book/src/commands/use_eks.md
+++ b/docs/book/src/commands/use_eks.md
@@ -28,9 +28,7 @@ kconnect use eks [flags]
   -c, --cluster-id string         Id of the cluster to use.
   -h, --help                      help for eks
       --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
-      --idp-endpoint string       identity provider endpoint provided by your IT team
       --idp-protocol string       The idp protocol to use (e.g. saml)
-      --idp-provider string       the name of the idp provider
   -k, --kubeconfig string         Location of the kubeconfig to use. (default "$HOME/.kube/config")
       --max-history int           Sets the maximum number of history items to keep (default 100)
       --namespace string          Sets namespace for context in kubeconfig

--- a/docs/book/src/commands/use_eks.md
+++ b/docs/book/src/commands/use_eks.md
@@ -28,7 +28,9 @@ kconnect use eks [flags]
   -c, --cluster-id string         Id of the cluster to use.
   -h, --help                      help for eks
       --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --idp-endpoint string       identity provider endpoint provided by your IT team
       --idp-protocol string       The idp protocol to use (e.g. saml)
+      --idp-provider string       the name of the idp provider
   -k, --kubeconfig string         Location of the kubeconfig to use. (default "$HOME/.kube/config")
       --max-history int           Sets the maximum number of history items to keep (default 100)
       --namespace string          Sets namespace for context in kubeconfig

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -117,6 +117,9 @@ func addConfig(cs config.ConfigurationSet) error {
 	if _, err := cs.String("output", "table", "Output format for the results"); err != nil {
 		return fmt.Errorf("adding output config item: %w", err)
 	}
+	if err := cs.SetShort("output", "o"); err != nil {
+		return fmt.Errorf("adding output short flag: %w", err)
+	}
 
 	cs.SetHistoryIgnore("output") //nolint
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Better comparison logic in history entries, ignores the protocol flag
Also adds shorthand -o flag to ls command
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #149 