### PR TITLE
feat: Profile name change

### DIFF
--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -24,15 +24,14 @@ import (
 // SharedConfig will return shared configuration items for AWS based cluster and identity providers
 func SharedConfig() config.ConfigurationSet {
 	cs := config.NewConfigurationSet()
-	cs.String("partition", endpoints.AwsPartition().ID(), "AWS partition to use") //nolint: errcheck
-	cs.String("region", "", "AWS region to connect to")                           //nolint: errcheck
-	cs.String("profile", "", "AWS profile to use")                                //nolint: errcheck
+	cs.String("partition", endpoints.AwsPartition().ID(), "AWS partition to use")      //nolint: errcheck
+	cs.String("region", "", "AWS region to connect to")                                //nolint: errcheck
+	cs.String("static-profile", "", "AWS profile to use. Only for advanced use cases") //nolint: errcheck
 
-	cs.SetRequired("profile")   //nolint: errcheck
 	cs.SetRequired("region")    //nolint: errcheck
 	cs.SetRequired("partition") //nolint: errcheck
 
-	cs.SetHidden("profile") //nolint: errcheck
+	cs.SetHidden("static-profile") //nolint: errcheck
 
 	return cs
 }

--- a/pkg/aws/identifer.go
+++ b/pkg/aws/identifer.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+
+	"github.com/versent/saml2aws/pkg/awsconfig"
+)
+
+var (
+	ErrPrincipleARNRequired = errors.New("principle arn is required ")
+)
+
+// CreateIDFromCreds will create a unique identifier for a set of credentials. The identifier
+// is a hash of the principle ARN
+func CreateIDFromCreds(creds *awsconfig.AWSCredentials) (string, error) {
+	if creds.PrincipalARN == "" {
+		return "", ErrPrincipleARNRequired
+	}
+	h := fnv.New32a()
+	if _, err := h.Write([]byte(creds.PrincipalARN)); err != nil {
+		return "", fmt.Errorf("write to has function: %w", err)
+	}
+
+	return fmt.Sprintf("%d", h.Sum32()), nil
+}

--- a/pkg/plugins/discovery/aws/config.go
+++ b/pkg/plugins/discovery/aws/config.go
@@ -26,8 +26,8 @@ import (
 )
 
 func (p *eksClusterProvider) GetClusterConfig(ctx *provider.Context, cluster *provider.Cluster, namespace string) (*api.Config, string, error) {
-	clusterName := fmt.Sprintf("kconnect-eks-%s", cluster.Name)
-	userName := fmt.Sprintf("kconnect-%s-%s", p.identity.ProfileName, cluster.Name)
+	clusterName := fmt.Sprintf("eks-%s", cluster.Name)
+	userName := p.identity.ProfileName
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
 
 	certData, err := base64.StdEncoding.DecodeString(*cluster.CertificateAuthorityData)

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -42,7 +42,6 @@ type eksClusteProviderConfig struct {
 	provider.ClusterProviderConfig
 	Region       *string `json:"region"`
 	RegionFilter *string `json:"region-filter"`
-	Profile      *string `json:"profile"`
 	RoleArn      *string `json:"role-arn"`
 	RoleFilter   *string `json:"role-filter"`
 }

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -30,7 +30,6 @@ import (
 
 func init() {
 	if err := provider.RegisterClusterProviderPlugin("eks", newEKSProvider()); err != nil {
-		// TODO: handle fatal error
 		zap.S().Fatalw("Failed to register EKS cluster provider plugin", "error", err)
 	}
 }

--- a/pkg/plugins/identity/saml/saml.go
+++ b/pkg/plugins/identity/saml/saml.go
@@ -62,7 +62,6 @@ func newSAMLProvider() *samlIdentityProvider {
 type samlIdentityProvider struct {
 	config          *sp.ProviderConfig
 	serviceProvider sp.ServiceProvider
-	store           provider.IdentityStore
 
 	logger *zap.SugaredLogger
 }
@@ -119,10 +118,6 @@ func (p *samlIdentityProvider) Authenticate(ctx *provider.Context, clusterProvid
 		return nil, fmt.Errorf("validating service provider: %w", err)
 	}
 
-	if err := p.createStore(ctx, clusterProvider); err != nil {
-		return nil, fmt.Errorf("creating identity store: %w", err)
-	}
-
 	account, err := p.createAccount(ctx.ConfigurationItems())
 	if err != nil {
 		return nil, ErrCreatingAccount
@@ -158,7 +153,12 @@ func (p *samlIdentityProvider) Authenticate(ctx *provider.Context, clusterProvid
 		return nil, fmt.Errorf("processing assertions for: %s: %w", clusterProvider, err)
 	}
 
-	err = p.store.Save(userID)
+	store, err := p.createIdentityStore(ctx, clusterProvider)
+	if err != nil {
+		return nil, fmt.Errorf("creating identity store for %s: %w", clusterProvider, err)
+	}
+
+	err = store.Save(userID)
 	if err != nil {
 		return nil, fmt.Errorf("saving identity: %w", err)
 	}
@@ -183,16 +183,6 @@ func (p *samlIdentityProvider) bindAndValidateConfig(cs config.ConfigurationSet)
 	return nil
 }
 
-func (p *samlIdentityProvider) createStore(ctx *provider.Context, providerName string) error {
-	store, err := p.createIdentityStore(ctx, providerName)
-	if err != nil {
-		return fmt.Errorf("creating identity store for %s: %w", providerName, err)
-	}
-	p.store = store
-
-	return nil
-}
-
 func (p *samlIdentityProvider) createAccount(cs config.ConfigurationSet) (*cfg.IDPAccount, error) {
 	account := &cfg.IDPAccount{
 		URL:             p.config.IdpEndpoint,
@@ -210,9 +200,13 @@ func (p *samlIdentityProvider) createAccount(cs config.ConfigurationSet) (*cfg.I
 func (p *samlIdentityProvider) resolveConfig(ctx *provider.Context) error {
 	sp := p.serviceProvider
 
-	p.logger.Debug("resolving SAML provider flags")
-	if err := sp.ResolveConfiguration(ctx.ConfigurationItems(), ctx.IsInteractive()); err != nil {
-		return fmt.Errorf("resolving flags: %w", err)
+	if ctx.IsInteractive() {
+		p.logger.Debug("resolving SAML provider flags")
+		if err := sp.ResolveConfiguration(ctx.ConfigurationItems()); err != nil {
+			return fmt.Errorf("resolving flags: %w", err)
+		}
+	} else {
+		p.logger.Debug("skipping configuration resolution as runnning non-interactive")
 	}
 
 	return nil

--- a/pkg/plugins/identity/saml/sp/aws/resolver.go
+++ b/pkg/plugins/identity/saml/sp/aws/resolver.go
@@ -37,33 +37,32 @@ const (
 func (p *ServiceProvider) ResolveConfiguration(cfg config.ConfigurationSet, interactive bool) error {
 	p.logger.Debug("resolving AWS identity configuration items")
 
+	if interactive {
+		// NOTE: resolution is only needed for required fields
+		if err := p.resolveIdpProvider("idp-provider", cfg); err != nil {
+			return fmt.Errorf("resolving idp-provider: %w", err)
+		}
+		if err := p.resolveIdpEndpoint("idp-endpoint", cfg); err != nil {
+			return fmt.Errorf("resolving idp-endpoint: %w", err)
+		}
+
+		if err := p.resolvePartition("partition", cfg); err != nil {
+			return fmt.Errorf("resolving partition: %w", err)
+		}
+		if err := p.resolveRegion("region", cfg); err != nil {
+			return fmt.Errorf("resolving region: %w", err)
+		}
+		if err := p.resolveUsername("username", cfg); err != nil {
+			return fmt.Errorf("resolving username: %w", err)
+		}
+		if err := p.resolvePassword("password", cfg); err != nil {
+			return fmt.Errorf("resolving password: %w", err)
+		}
+	}
+
+	// NOTE: profile is last as it will use other config items
 	if err := p.resolveProfile("profile", cfg); err != nil {
 		return fmt.Errorf("resolving profile: %w", err)
-	}
-
-	if !interactive {
-		return nil
-	}
-
-	// NOTE: resolution is only needed for required fields
-	if err := p.resolveIdpProvider("idp-provider", cfg); err != nil {
-		return fmt.Errorf("resolving idp-provider: %w", err)
-	}
-	if err := p.resolveIdpEndpoint("idp-endpoint", cfg); err != nil {
-		return fmt.Errorf("resolving idp-endpoint: %w", err)
-	}
-
-	if err := p.resolvePartition("partition", cfg); err != nil {
-		return fmt.Errorf("resolving partition: %w", err)
-	}
-	if err := p.resolveRegion("region", cfg); err != nil {
-		return fmt.Errorf("resolving region: %w", err)
-	}
-	if err := p.resolveUsername("username", cfg); err != nil {
-		return fmt.Errorf("resolving username: %w", err)
-	}
-	if err := p.resolvePassword("password", cfg); err != nil {
-		return fmt.Errorf("resolving password: %w", err)
 	}
 
 	return nil

--- a/pkg/plugins/identity/saml/sp/aws/store.go
+++ b/pkg/plugins/identity/saml/sp/aws/store.go
@@ -26,10 +26,10 @@ import (
 
 // NewIdentityStore will create a new AWS identity store
 func NewIdentityStore(cfg config.ConfigurationSet) (provider.IdentityStore, error) {
-	if !cfg.ExistsWithValue("profile") {
+	if !cfg.ExistsWithValue("aws-profile") {
 		return nil, ErrNoProfile
 	}
-	profileCfg := cfg.Get("profile")
+	profileCfg := cfg.Get("aws-profile")
 	profile := profileCfg.Value.(string)
 
 	return &awsIdentityStore{

--- a/pkg/plugins/identity/saml/sp/types.go
+++ b/pkg/plugins/identity/saml/sp/types.go
@@ -33,7 +33,7 @@ type ServiceProvider interface {
 	ConfigurationItems() config.ConfigurationSet
 
 	Validate(configItems config.ConfigurationSet) error
-	ResolveConfiguration(configItems config.ConfigurationSet, interactive bool) error
+	ResolveConfiguration(configItems config.ConfigurationSet) error
 	PopulateAccount(account *cfg.IDPAccount, configItems config.ConfigurationSet) error
 	ProcessAssertions(account *cfg.IDPAccount, samlAssertions string, configItems config.ConfigurationSet) (provider.Identity, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the AWS profile to be generated from a hash of the PrincipleARN. This is so it is re-used.

Also, the cluster/context/username have been shortened in the kubeconfig

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #