### PR TITLE
feat: sort by last used timestamp for ls command

### DIFF
--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -51,7 +51,7 @@ type HistoryQueryInput struct {
 func (a *App) QueryHistory(ctx *provider.Context, input *HistoryQueryInput) error {
 	zap.S().Debug("querying history")
 
-	list, err := a.historyStore.GetAll()
+	list, err := a.historyStore.GetAllSortedByLastUsed()
 	if err != nil {
 		return fmt.Errorf("getting history entries: %w", err)
 	}

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -32,4 +32,5 @@ type Store interface {
 	GetByAlias(alias string) (*historyv1alpha.HistoryEntry, error)
 	GetLastModified(index int) (*historyv1alpha.HistoryEntry, error)
 	Update(entry *historyv1alpha.HistoryEntry) error
+	GetAllSortedByLastUsed() (*historyv1alpha.HistoryEntryList, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Display the results sorted by `LastUsed` timestamp with the most recently used first when using `kconnect ls` command

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #156