### PR TITLE
fix: running in docker resulted in permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM gcr.io/distroless/static:latest
+FROM scratch
 
-USER root
-COPY --chown=nonroot:nonroot kconnect /
+COPY  kconnect /
 
-USER nonroot
 ENTRYPOINT ["/kconnect"]

--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -33,5 +33,5 @@ You can also use kconnect via Docker by using the images we publish to Docker Hu
 
 ```bash
 docker pull docker.io/kconnectcli/kconnect:latest
-docker run -v ~/.kconnect:/home/nonroot/.kconnect kconnect:test use eks --idp-protocol saml
+docker run -it --rm -v ~/.kconnect:/.kconnect kconnect:latest use eks --idp-protocol saml
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
When running in docker user where experiencing a permission denied error when running kconnect for the first time.

The installation instructions have also neeb updated.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #