### PR TITLE
feat: Filter wildcard

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4 h1:5Myjjh3JY/NaAi4IsUbHADytDyl1VE1Y9PXDlL+P/VQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/internal/app/to.go
+++ b/internal/app/to.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/printer"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 type ConnectToParams struct {
@@ -167,7 +168,10 @@ func (a *App) getInteractive(params *ConnectToParams) (*historyv1alpha.HistoryEn
 	prompt := &survey.Select{
 		Message: "Select a history entry",
 		Options: options,
+		Filter: utils.SurveyFilter,
 	}
+
+	
 	if err := survey.AskOne(prompt, &selectedEntryString, survey.WithValidator(survey.Required)); err != nil {
 		return nil, fmt.Errorf("asking for entry: %w", err)
 	}

--- a/internal/app/to.go
+++ b/internal/app/to.go
@@ -168,7 +168,7 @@ func (a *App) getInteractive(params *ConnectToParams) (*historyv1alpha.HistoryEn
 	prompt := &survey.Select{
 		Message: "Select a history entry",
 		Options: options,
-		Filter: utils.SurveyFilter,
+		Filter:  utils.SurveyFilter,
 	}
 	if err := survey.AskOne(prompt, &selectedEntryString, survey.WithValidator(survey.Required)); err != nil {
 		return nil, fmt.Errorf("asking for entry: %w", err)

--- a/internal/app/to.go
+++ b/internal/app/to.go
@@ -170,8 +170,6 @@ func (a *App) getInteractive(params *ConnectToParams) (*historyv1alpha.HistoryEn
 		Options: options,
 		Filter: utils.SurveyFilter,
 	}
-
-	
 	if err := survey.AskOne(prompt, &selectedEntryString, survey.WithValidator(survey.Required)); err != nil {
 		return nil, fmt.Errorf("asking for entry: %w", err)
 	}

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -20,10 +20,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/beevik/etree"
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/zap"
@@ -252,11 +254,15 @@ func (p *ServiceProvider) getRoleFromPrompt(accounts []*saml2aws.AWSAccount) (*s
 	sort.Strings(roleOptions)
 	selectedRole := ""
 	prompt := &survey.Select{
-		Message: "Select an AWS region",
+		Message: "Select an AWS role",
 		Options: roleOptions,
 		Filter:  utils.SurveyFilter,
 	}
 	if err := survey.AskOne(prompt, &selectedRole, survey.WithValidator(survey.Required)); err != nil {
+		if err == terminal.InterruptErr {
+			fmt.Println("Received interrupt, exiting..")
+			os.Exit(0)
+		}
 		return nil, fmt.Errorf("asking for region: %w", err)
 	}
 	return roles[selectedRole], nil

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -259,7 +259,7 @@ func (p *ServiceProvider) getRoleFromPrompt(accounts []*saml2aws.AWSAccount) (*s
 		Filter:  utils.SurveyFilter,
 	}
 	if err := survey.AskOne(prompt, &selectedRole, survey.WithValidator(survey.Required)); err != nil {
-		if err == terminal.InterruptErr {
+		if errors.Is(err, terminal.InterruptErr) {
 			fmt.Println("Received interrupt, exiting..")
 			os.Exit(0)
 		}

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -208,7 +208,6 @@ func (p *ServiceProvider) resolveRole(awsRoles []*saml2aws.AWSRole, samlAssertio
 	}
 
 	for {
-		//role, err = saml2aws.PromptForAWSRoleSelection(awsAccounts)
 		role, err = p.getRoleFromPrompt(awsAccounts)
 		if err == nil {
 			break
@@ -250,9 +249,7 @@ func (p *ServiceProvider) getRoleFromPrompt(accounts []*saml2aws.AWSAccount) (*s
 			roleOptions = append(roleOptions, name)
 		}
 	}
-
 	sort.Strings(roleOptions)
-
 	selectedRole := ""
 	prompt := &survey.Select{
 		Message: "Select an AWS region",

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -254,15 +254,13 @@ func (p *ServiceProvider) getRoleFromPrompt(accounts []*saml2aws.AWSAccount) (*s
 	prompt := &survey.Select{
 		Message: "Select an AWS region",
 		Options: roleOptions,
-		Filter: utils.SurveyFilter,
+		Filter:  utils.SurveyFilter,
 	}
 	if err := survey.AskOne(prompt, &selectedRole, survey.WithValidator(survey.Required)); err != nil {
 		return nil, fmt.Errorf("asking for region: %w", err)
 	}
 	return roles[selectedRole], nil
 }
-
-
 
 func (p *ServiceProvider) loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAssertion string) (*awsconfig.AWSCredentials, error) {
 	sess, err := session.NewSession(&aws.Config{

--- a/pkg/plugins/identity/saml/sp/aws/resolver.go
+++ b/pkg/plugins/identity/saml/sp/aws/resolver.go
@@ -132,7 +132,7 @@ func (p *ServiceProvider) resolveRegion(name string, cfg config.ConfigurationSet
 	prompt := &survey.Select{
 		Message: "Select an AWS region",
 		Options: options,
-		Filter: utils.SurveyFilter,
+		Filter:  utils.SurveyFilter,
 	}
 	if err := survey.AskOne(prompt, &region, survey.WithValidator(survey.Required)); err != nil {
 		return fmt.Errorf("asking for region: %w", err)

--- a/pkg/plugins/identity/saml/sp/aws/resolver.go
+++ b/pkg/plugins/identity/saml/sp/aws/resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
 	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 // ResolveConfiguration will resolve the values for the AWS specific config items that have no value.
@@ -131,6 +132,7 @@ func (p *ServiceProvider) resolveRegion(name string, cfg config.ConfigurationSet
 	prompt := &survey.Select{
 		Message: "Select an AWS region",
 		Options: options,
+		Filter: utils.SurveyFilter,
 	}
 	if err := survey.AskOne(prompt, &region, survey.WithValidator(survey.Required)); err != nil {
 		return fmt.Errorf("asking for region: %w", err)

--- a/pkg/utils/filter.go
+++ b/pkg/utils/filter.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// SurveyFilter a function for passing to AlecAivazis/survey, which will allow wildcards(*) and whitespace to be used for subfilter values
+func SurveyFilter(filter string, value string, index int) bool {
+	newString := regexp.MustCompile("[\\s]+").ReplaceAllString(filter, "*")
+	subFilters := strings.Split(newString, "*")
+	for _, s := range(subFilters) {
+		if !strings.Contains(value, s) && s != "" {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/utils/filter.go
+++ b/pkg/utils/filter.go
@@ -7,8 +7,8 @@ import (
 
 // SurveyFilter a function for passing to AlecAivazis/survey, which will allow wildcards(*) and whitespace to be used for subfilter values
 func SurveyFilter(filter string, value string, index int) bool {
-	newString := regexp.MustCompile("[\\s]+").ReplaceAllString(filter, "*")
-	subFilters := strings.Split(newString, "*")
+	parsedFilter := regexp.MustCompile("[\\s]+").ReplaceAllString(filter, "*")
+	subFilters := strings.Split(parsedFilter, "*")
 	for _, s := range(subFilters) {
 		if !strings.Contains(value, s) && s != "" {
 			return false

--- a/pkg/utils/filter.go
+++ b/pkg/utils/filter.go
@@ -7,9 +7,9 @@ import (
 
 // SurveyFilter a function for passing to AlecAivazis/survey, which will allow wildcards(*) and whitespace to be used for subfilter values
 func SurveyFilter(filter string, value string, index int) bool {
-	parsedFilter := regexp.MustCompile("[\\s]+").ReplaceAllString(filter, "*")
+	parsedFilter := regexp.MustCompile(`[\s]+`).ReplaceAllString(filter, "*")
 	subFilters := strings.Split(parsedFilter, "*")
-	for _, s := range(subFilters) {
+	for _, s := range subFilters {
 		if !strings.Contains(value, s) && s != "" {
 			return false
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,73 @@
+package utils
+
+import "testing"
+
+
+func Test_Filter(t *testing.T) {
+	testCases := []struct {
+		name            string
+		inputValue      string 
+		inputFilter     string
+		expect          bool
+	}{
+		{
+			name:            "Simple match",
+			inputValue:      "this is a simple string",
+			inputFilter:     "simple",
+			expect:          true,
+		},
+		{
+			name:            "Simple mismatch",
+			inputValue:      "this is a simple string",
+			inputFilter:     "isnt",
+			expect:          false,
+		},
+		{
+			name:            "Multiple match (*)",
+			inputValue:      "this is a simple string",
+			inputFilter:     "simple*this",
+			expect:          true,
+		},
+		{
+			name:            "Multiple mismatch (*)",
+			inputValue:      "this is a simple string",
+			inputFilter:     "string*isnt",
+			expect:          false,
+		},
+		{
+			name:            "Multiple match (whitespace)",
+			inputValue:      "this is a simple string",
+			inputFilter:     "string this",
+			expect:          true,
+		},
+		{
+			name:            "Multiple mismatch (whitespace)",
+			inputValue:      "this is a simple string",
+			inputFilter:     "string mismatch",
+			expect:          false,
+		},
+		{
+			name:            "Multiple match (* + whitespace)",
+			inputValue:      "this is a simple string",
+			inputFilter:     "string*this*string",
+			expect:          true,
+		},
+		{
+			name:            "Multiple mismatch (* + whitespace)",
+			inputValue:      "this is a simple string",
+			inputFilter:     "string*is a mismatch",
+			expect:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := SurveyFilter(tc.inputFilter, tc.inputValue, 0)
+			if actual != tc.expect {
+				t.Fatalf("expected %t but got %t", tc.expect, actual)
+			}
+		})
+	}
+
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows wildcard filters in survey selections, such as history entry, region, and aws role selection
You can provide * or a space to separate a filter into subfilters
Only entries which match all subfilters will be shown e.g.

`? Select an AWS region 123 EKS  [Use arrows to move, type to filter]
> Account: account-1 (123456789) / EKS_Role1
   Account: account-2 (123123123) / EKS_Role2`



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #182 