### PR TITLE
feat: history id is lower case

### DIFF
--- a/api/v1alpha1/history_types.go
+++ b/api/v1alpha1/history_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"math/rand"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/oklog/ulid"
@@ -106,7 +107,7 @@ func NewHistoryEntry() *HistoryEntry {
 			Kind:       "HistoryEntry",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              id.String(),
+			Name:              strings.ToLower(id.String()),
 			CreationTimestamp: created,
 			Generation:        1,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the history id to be lower case. This is so its more consistent with other kubernetes cli tools like kubctl that uses lower case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #190 