### PR TITLE
feat: specify subscription by name for AKS

### DIFF
--- a/docs/book/src/commands/use_aks.md
+++ b/docs/book/src/commands/use_aks.md
@@ -41,21 +41,22 @@ kconnect use aks [flags]
 ### Options
 
 ```bash
-      --admin                     Generate admin user kubeconfig
-  -a, --alias string              Friendly name to give to give the connection
-  -c, --cluster-id string         Id of the cluster to use.
-  -h, --help                      help for aks
-      --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
-      --idp-protocol string       The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.
-  -k, --kubeconfig string         Location of the kubeconfig to use. (default "$HOME/.kube/config")
-      --max-history int           Sets the maximum number of history items to keep (default 100)
-  -n, --namespace string          Sets namespace for context in kubeconfig
-      --no-history                If set to true then no history entry will be written
-      --password string           The password to use for authentication
-  -r, --resource-group string     The Azure resource group to use
-      --set-current               Sets the current context in the kubeconfig to the selected cluster (default true)
-  -s, --subscription-id string    The Azure subscription to use
-      --username string           The username used for authentication
+      --admin                      Generate admin user kubeconfig
+  -a, --alias string               Friendly name to give to give the connection
+  -c, --cluster-id string          Id of the cluster to use.
+  -h, --help                       help for aks
+      --history-location string    Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --idp-protocol string        The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.
+  -k, --kubeconfig string          Location of the kubeconfig to use. (default "$HOME/.kube/config")
+      --max-history int            Sets the maximum number of history items to keep (default 100)
+  -n, --namespace string           Sets namespace for context in kubeconfig
+      --no-history                 If set to true then no history entry will be written
+      --password string            The password to use for authentication
+  -r, --resource-group string      The Azure resource group to use
+      --set-current                Sets the current context in the kubeconfig to the selected cluster (default true)
+      --subscription-id string     The Azure subscription to use (specified by ID)
+      --subscription-name string   The Azure subscription to use (specified by name)
+      --username string            The username used for authentication
 ```
 
 ### Options inherited from parent commands

--- a/pkg/plugins/discovery/azure/defaults.go
+++ b/pkg/plugins/discovery/azure/defaults.go
@@ -17,9 +17,11 @@ limitations under the License.
 package azure
 
 const (
-	TenantIDConfigItem       = "tenant-id"
-	ClientIDConfigItem       = "client-id"
-	AADHostConfigItem        = "aad-host"
-	SubscriptionIDConfigItem = "subscription-id"
-	ResourceGroupConfigItem  = "resource-group"
+	TenantIDConfigItem         = "tenant-id"
+	ClientIDConfigItem         = "client-id"
+	AADHostConfigItem          = "aad-host"
+	SubscriptionIDConfigItem   = "subscription-id"
+	SubscriptionNameConfigItem = "subscription-name"
+	ResourceGroupConfigItem    = "resource-group"
+	AdminConfigItem            = "admin"
 )

--- a/pkg/plugins/discovery/azure/errors.go
+++ b/pkg/plugins/discovery/azure/errors.go
@@ -19,7 +19,9 @@ package azure
 import "errors"
 
 var (
-	ErrNotOIDCIdentity = errors.New("unsupported identity, oidc.Identity required")
-	ErrNoKubeconfigs   = errors.New("no kubeconfigs available for the managed cluster cluster")
-	ErrNoSubscriptions = errors.New("no subscriptions found")
+	ErrNotOIDCIdentity      = errors.New("unsupported identity, oidc.Identity required")
+	ErrNoKubeconfigs        = errors.New("no kubeconfigs available for the managed cluster cluster")
+	ErrNoSubscriptions      = errors.New("no subscriptions found")
+	ErrSubscriptionNameOrID = errors.New("subscription name and id cannot be both supplied")
+	ErrSubscriptionNotFound = errors.New("subscription not found")
 )

--- a/pkg/plugins/discovery/azure/provider.go
+++ b/pkg/plugins/discovery/azure/provider.go
@@ -44,9 +44,10 @@ func newAKSProvider() *aksClusterProvider {
 
 type aksClusterProviderConfig struct {
 	provider.ClusterProviderConfig
-	SubscriptionID *string `json:"subscription-id"`
-	ResourceGroup  *string `json:"resource-group"`
-	Admin          bool    `json:"admin"`
+	SubscriptionID   *string `json:"subscription-id"`
+	SubscriptionName *string `json:"subscription-name"`
+	ResourceGroup    *string `json:"resource-group"`
+	Admin            bool    `json:"admin"`
 }
 
 type aksClusterProvider struct {
@@ -68,12 +69,12 @@ func (p *aksClusterProvider) SupportedIDs() []string {
 func (p *aksClusterProvider) ConfigurationItems() config.ConfigurationSet {
 	cs := config.NewConfigurationSet()
 
-	cs.String(SubscriptionIDConfigItem, "", "The Azure subscription to use")  //nolint: errcheck
-	cs.String(ResourceGroupConfigItem, "", "The Azure resource group to use") //nolint: errcheck
-	cs.Bool("admin", false, "Generate admin user kubeconfig")                 //nolint: errcheck
+	cs.String(SubscriptionIDConfigItem, "", "The Azure subscription to use (specified by ID)")     //nolint: errcheck
+	cs.String(SubscriptionNameConfigItem, "", "The Azure subscription to use (specified by name)") //nolint: errcheck
+	cs.String(ResourceGroupConfigItem, "", "The Azure resource group to use")                      //nolint: errcheck
+	cs.Bool(AdminConfigItem, false, "Generate admin user kubeconfig")                              //nolint: errcheck
 
-	cs.SetShort(ResourceGroupConfigItem, "r")  //nolint: errcheck
-	cs.SetShort(SubscriptionIDConfigItem, "s") //nolint: errcheck
+	cs.SetShort(ResourceGroupConfigItem, "r") //nolint: errcheck
 
 	return cs
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow users to specify a subscription by name. This will be better UX.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #191 