### PR TITLE
fix: show reconnect help text correctly

### DIFF
--- a/internal/app/use.go
+++ b/internal/app/use.go
@@ -221,7 +221,7 @@ func (a *App) resolveAndCheckAlias(params *UseParams) error {
 		return ErrAliasAlreadyUsed
 	}
 
-	zap.S().Infof("Command to reconnect using this alias: kconnect to %s", params.Alias)
+	zap.S().Infof("Command to reconnect using this alias: kconnect to %s", *params.Alias)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The reconnect help text wasn't displaying correctly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #198 