### PR TITLE
fix: apply global config for the to command

### DIFF
--- a/internal/app/to.go
+++ b/internal/app/to.go
@@ -267,6 +267,10 @@ func (a *App) buildConnectToConfig(idProvider provider.IdentityProvider, cluster
 		}
 	}
 
+	if err := config.ApplyToConfigSetWithProvider(cs, clusterProvider.Name()); err != nil {
+		return nil, fmt.Errorf("applying app config: %w", err)
+	}
+
 	for _, configItem := range cs.GetAll() {
 		if !configItem.HasValue() {
 			configItem.Value = configItem.DefaultValue


### PR DESCRIPTION
**What this PR does / why we need it**:
The kconnect global config is applied to the configuration items when using the `to` command

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #199 