### PR TITLE
docs: change in sequence of steps in contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,23 +47,23 @@ When choosing an issue to work on its preferable that you choose a issue that is
 git checkout -b <feature-name>
 ```
 
-4. Make the change, including any additional tests
-5. Run the tests:
+4. Use `git submodule` for saml2aws third party dependency
+
+```bash
+git submodule update --init --recursive
+```
+
+5. Make the change, including any additional tests
+6. Run the tests:
 
 ```bash
 make test
 ```
 
-6. Check for linting errors:
+7. Check for linting errors:
 
 ```bash
 make lint
-```
-
-7. Use `git submodule` for saml2aws third party dependency
-
-```bash
-git submodule update --init --recursive
 ```
 
 8. Build and manually test kconnect locally:


### PR DESCRIPTION
Change in sequence of steps in contributor guide

**What this PR does / why we need it**:
Changed the sequence of tests required for building the source code in contributor guide. 

We can also looking at the feasibility of downloading this module automatically if it is not present


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Documentation improvement