### PR TITLE
feat: added cluster-name flag to AKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ hack/tools/share
 *.swp
 
 .vscode/
+.idea/
 
 .DS_Store
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,3 +32,8 @@ linters:
     - godot
     - godox
     - maligned
+    - nlreturn
+    - exhaustivestruct
+    - gofumpt
+    - gci
+    - wrapcheck # enable in the future

--- a/api/v1alpha1/history_types.go
+++ b/api/v1alpha1/history_types.go
@@ -97,7 +97,7 @@ func NewHistoryEntryList() *HistoryEntryList {
 
 func NewHistoryEntry() *HistoryEntry {
 	t := time.Now()
-	entropy := ulid.Monotonic(rand.New(rand.NewSource(t.UnixNano())), 0)
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(t.UnixNano())), 0) //nolint: gosec
 	id := ulid.MustNew(ulid.Timestamp(t), entropy)
 
 	created := metav1.Now()
@@ -242,6 +242,6 @@ func getTimeLeft(entry *HistoryEntry) string {
 	} else {
 		return "NA"
 	}
-	//TODO - other variations e.g. AKS
+	// TODO - other variations e.g. AKS
 	return htime.GetRemainingTime(expiresTime)
 }

--- a/docs/book/src/commands/use_aks.md
+++ b/docs/book/src/commands/use_aks.md
@@ -50,6 +50,7 @@ kconnect use aks [flags]
       --admin                      Generate admin user kubeconfig
   -a, --alias string               Friendly name to give to give the connection
   -c, --cluster-id string          Id of the cluster to use.
+      --cluster-name string        The name of the AKS cluster
   -h, --help                       help for aks
       --history-location string    Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
       --idp-protocol string        The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/mock v1.4.4
-	github.com/golangci/golangci-lint v1.27.0
+	github.com/golangci/golangci-lint v1.33.0
 	github.com/spf13/cobra v1.0.0
 	k8s.io/code-generator v0.19.1
 	sigs.k8s.io/controller-tools v0.2.9

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -88,8 +88,6 @@ func (a *App) QueryHistory(ctx *provider.Context, input *HistoryQueryInput) erro
 }
 
 func (a *App) getCurrentContextID(kubecfg string) (string, error) {
-
-	//get context
 	currentContext, err := kubeconfig.GetCurrentContext(kubecfg)
 	if err != nil {
 		return "", err

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fidelity/kconnect/internal/version"
 )
 
-//Command creates the version cobra command
+// Command creates the version cobra command
 func Command() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/pkg/azure/client/client.go
+++ b/pkg/azure/client/client.go
@@ -26,13 +26,15 @@ import (
 	"github.com/fidelity/kconnect/internal/version"
 )
 
-var ()
+const (
+	userAgentTemplate = "kconnect.fidelity.github.com/%s"
+)
 
 // NewContainerClient will create a new Azure container services client
 func NewContainerClient(subscriptionID string, authorizer autorest.Authorizer) containerservice.ManagedClustersClient {
 	azclient := containerservice.NewManagedClustersClient(subscriptionID)
 	azclient.Authorizer = authorizer
-	azclient.UserAgent = fmt.Sprintf("kconnect.fidelity.github.com/%s", version.Get().String())
+	azclient.UserAgent = fmt.Sprintf(userAgentTemplate, version.Get().String())
 
 	return azclient
 }
@@ -41,7 +43,7 @@ func NewContainerClient(subscriptionID string, authorizer autorest.Authorizer) c
 func NewSubscriptionsClient(authorizer autorest.Authorizer) subscriptions.Client {
 	subClient := subscriptions.NewClient()
 	subClient.Authorizer = authorizer
-	subClient.UserAgent = fmt.Sprintf("kconnect.fidelity.github.com/%s", version.Get().String())
+	subClient.UserAgent = fmt.Sprintf(userAgentTemplate, version.Get().String())
 
 	return subClient
 }

--- a/pkg/azure/client/client.go
+++ b/pkg/azure/client/client.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-09-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-11-01/subscriptions"
+	"github.com/Azure/go-autorest/autorest"
+
+	"github.com/fidelity/kconnect/internal/version"
+)
+
+var ()
+
+// NewContainerClient will create a new Azure container services client
+func NewContainerClient(subscriptionID string, authorizer autorest.Authorizer) containerservice.ManagedClustersClient {
+	azclient := containerservice.NewManagedClustersClient(subscriptionID)
+	azclient.Authorizer = authorizer
+	azclient.UserAgent = fmt.Sprintf("kconnect.fidelity.github.com/%s", version.Get().String())
+
+	return azclient
+}
+
+// NewSubscriptionsClient will create a new Azure subscriptions client
+func NewSubscriptionsClient(authorizer autorest.Authorizer) subscriptions.Client {
+	subClient := subscriptions.NewClient()
+	subClient.Authorizer = authorizer
+	subClient.UserAgent = fmt.Sprintf("kconnect.fidelity.github.com/%s", version.Get().String())
+
+	return subClient
+}

--- a/pkg/azure/identity/endpoints.go
+++ b/pkg/azure/identity/endpoints.go
@@ -98,7 +98,7 @@ func (r *oidcEndpointsResolver) Resolve(cfg *AuthorityConfig) (*Endpoints, error
 	endpoints := &Endpoints{
 		AuthorizationEndpoint: oidcResp.AuthorizationEndpoint,
 		TokenEndpoint:         oidcResp.TokenEndpoint,
-		DeviceCodeEndpoint:    strings.Replace(oidcResp.TokenEndpoint, "token", "devicecode", -1),
+		DeviceCodeEndpoint:    strings.ReplaceAll(oidcResp.TokenEndpoint, "token", "devicecode"),
 	}
 
 	return endpoints, nil

--- a/pkg/azure/identity/types.go
+++ b/pkg/azure/identity/types.go
@@ -52,7 +52,7 @@ type Endpoints struct {
 	DeviceCodeEndpoint    string
 }
 
-//UserRealm is used to represent the details of a user
+// UserRealm is used to represent the details of a user
 type UserRealm struct {
 	AccountType           AccountType `json:"account_type"`
 	DomainName            string      `json:"domain_name"`
@@ -109,7 +109,7 @@ type RequestedSecurityToken struct {
 type OauthToken struct {
 	Type         string      `json:"token_type"`
 	Scope        string      `json:"scope"`
-	ExpiresIn    json.Number `json:"expires_in"` //seconds
+	ExpiresIn    json.Number `json:"expires_in"` // seconds
 	ExpiresOn    json.Number `json:"expires_on"`
 	NotBefore    json.Number `json:"not_before"`
 	Resource     string      `json:"resource"`

--- a/pkg/errors/validation.go
+++ b/pkg/errors/validation.go
@@ -46,7 +46,7 @@ func (e *ValidationFailed) setup() {
 }
 
 func IsValidationFailed(err error) bool {
-	if _, ok := err.(*ValidationFailed); ok {
+	if _, ok := err.(*ValidationFailed); ok { //nolint: errorlint
 		return true
 	}
 

--- a/pkg/flags/unmarshal.go
+++ b/pkg/flags/unmarshal.go
@@ -148,7 +148,7 @@ func unmarshallFlag(flag *pflag.Flag, out reflect.Value) error {
 
 	flagValueStr := flag.Value.String()
 
-	switch fieldT.Kind() {
+	switch fieldT.Kind() { //nolint: exhaustive
 	case reflect.String:
 		out.SetString(flagValueStr)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/pkg/http/http_client.go
+++ b/pkg/http/http_client.go
@@ -58,7 +58,6 @@ func (n *netHTTPClient) Do(req *ClientRequest) (ClientResponse, error) {
 	}
 
 	zap.S().Debugw("http request", "url", req.URL, "method", req.Method, "headers", req.Headers)
-	//zap.S().Debug(*req.Body)
 
 	resp, err := n.client.Do(r)
 	if err != nil {

--- a/pkg/plugins/discovery/azure/config.go
+++ b/pkg/plugins/discovery/azure/config.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	azclient "github.com/fidelity/kconnect/pkg/azure/client"
 	"github.com/fidelity/kconnect/pkg/azure/id"
 	"github.com/fidelity/kconnect/pkg/provider"
 )
@@ -50,8 +51,7 @@ func (p *aksClusterProvider) getKubeconfig(ctx context.Context, cluster *provide
 		return nil, fmt.Errorf("parsing cluster id: %w", err)
 	}
 
-	client := containerservice.NewManagedClustersClient(resourceID.SubscriptionID)
-	client.Authorizer = p.authorizer
+	client := azclient.NewContainerClient(resourceID.SubscriptionID, p.authorizer)
 
 	var credentialList containerservice.CredentialResults
 	if p.config.Admin {

--- a/pkg/plugins/discovery/azure/defaults.go
+++ b/pkg/plugins/discovery/azure/defaults.go
@@ -24,4 +24,5 @@ const (
 	SubscriptionNameConfigItem = "subscription-name"
 	ResourceGroupConfigItem    = "resource-group"
 	AdminConfigItem            = "admin"
+	ClusterNameConfigItem      = "cluster-name"
 )

--- a/pkg/plugins/discovery/azure/get.go
+++ b/pkg/plugins/discovery/azure/get.go
@@ -19,8 +19,7 @@ package azure
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-09-01/containerservice"
-
+	azclient "github.com/fidelity/kconnect/pkg/azure/client"
 	"github.com/fidelity/kconnect/pkg/azure/id"
 	"github.com/fidelity/kconnect/pkg/provider"
 )
@@ -37,9 +36,7 @@ func (p *aksClusterProvider) Get(ctx *provider.Context, clusterID string, identi
 		return nil, fmt.Errorf("getting resource id: %w", err)
 	}
 
-	client := containerservice.NewManagedClustersClient(resourceID.SubscriptionID)
-	client.Authorizer = p.authorizer
-
+	client := azclient.NewContainerClient(resourceID.SubscriptionID, p.authorizer)
 	result, err := client.Get(ctx.Context, resourceID.ResourceGroupName, resourceID.ResourceName)
 	if err != nil {
 		return nil, fmt.Errorf("getting cluster: %w", err)

--- a/pkg/plugins/discovery/azure/provider.go
+++ b/pkg/plugins/discovery/azure/provider.go
@@ -49,6 +49,7 @@ type aksClusterProviderConfig struct {
 	SubscriptionName *string `json:"subscription-name"`
 	ResourceGroup    *string `json:"resource-group"`
 	Admin            bool    `json:"admin"`
+	ClusterName      string  `json:"cluster-name"`
 }
 
 type aksClusterProvider struct {
@@ -74,6 +75,7 @@ func (p *aksClusterProvider) ConfigurationItems() config.ConfigurationSet {
 	cs.String(SubscriptionNameConfigItem, "", "The Azure subscription to use (specified by name)") //nolint: errcheck
 	cs.String(ResourceGroupConfigItem, "", "The Azure resource group to use")                      //nolint: errcheck
 	cs.Bool(AdminConfigItem, false, "Generate admin user kubeconfig")                              //nolint: errcheck
+	cs.String(ClusterNameConfigItem, "", "The name of the AKS cluster")                            //nolint: errcheck
 
 	cs.SetShort(ResourceGroupConfigItem, "r") //nolint: errcheck
 

--- a/pkg/plugins/discovery/azure/resolver.go
+++ b/pkg/plugins/discovery/azure/resolver.go
@@ -20,8 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-11-01/subscriptions"
-
+	azclient "github.com/fidelity/kconnect/pkg/azure/client"
 	"github.com/fidelity/kconnect/pkg/config"
 	kerrors "github.com/fidelity/kconnect/pkg/errors"
 	"github.com/fidelity/kconnect/pkg/provider"
@@ -96,8 +95,7 @@ func (p *aksClusterProvider) resolveSubscripionName(cfg config.ConfigurationSet)
 }
 
 func (p *aksClusterProvider) subscriptionOptions() (map[string]string, error) {
-	client := subscriptions.NewClient()
-	client.Authorizer = p.authorizer
+	client := azclient.NewSubscriptionsClient(p.authorizer)
 
 	res, err := client.List(context.TODO())
 	if err != nil {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -145,10 +145,7 @@ func (t *TokenIdentity) Name() string {
 }
 
 func (t *TokenIdentity) IsExpired() bool {
-	//TODO: handle properly
-	//now := time.Now().UTC()
-	//return now.After(i.Expires)
-
+	// TODO: handle properly
 	return false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `--cluster-name` flag to the AKS provider so that you can use it to select a specific cluster in a subscription/resource group instead of having to use the `--cluster-id` which is less user friendly

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #234 