### PR TITLE
fix: version check fails when missing last version

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -269,9 +269,11 @@ func reportNewerVersion() error {
 		}
 	} else {
 		zap.S().Debugw("latest version not retrieved as check interval not exceeded", "diffMins", checkDiff.Minutes(), "savedVersion", cfg.Spec.VersionCheck.LatestReleaseVersion)
-		latestSemver, err = semver.Parse(*cfg.Spec.VersionCheck.LatestReleaseVersion)
-		if err != nil {
-			return fmt.Errorf("parsing saved latest release version %s: %w", *cfg.Spec.VersionCheck.LatestReleaseVersion, err)
+		if cfg.Spec.VersionCheck.LatestReleaseVersion != nil && *cfg.Spec.VersionCheck.LatestReleaseVersion != "" {
+			latestSemver, err = semver.Parse(*cfg.Spec.VersionCheck.LatestReleaseVersion)
+			if err != nil {
+				return fmt.Errorf("parsing saved latest release version %s: %w", *cfg.Spec.VersionCheck.LatestReleaseVersion, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
An exception occured during version checking if there was no last version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #255 