### PR TITLE
build: remove version numbers from deb/rpm package file names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,7 @@ nfpms:
     package_name: kconnect
     replacements:
       darwin: macos
+    file_name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     vendor: kconnect authors
     homepage: https://github.com/fidelity/kconnect
     description: "The Kubernetes Connection Manager CLI"


### PR DESCRIPTION
**What this PR does / why we need it**:
This removed the version number from the published file names for the .deb & .rpm packages. This is to make it easier to script the download of the latest version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #260 