### PR TITLE
feat: renamed configure command to config for consistency

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -8,7 +8,7 @@
     - [add](./commands/alias_add.md)
     - [ls](./commands/alias_ls.md)
     - [remove](./commands/alias_remove.md)
-  - [configure](./commands/configure.md)
+  - [config](./commands/config.md)
   - [ls](./commands/ls.md)
   - [to](./commands/to.md)
   - [use](./commands/use.md)

--- a/docs/book/src/commands/config.md
+++ b/docs/book/src/commands/config.md
@@ -1,4 +1,4 @@
-## kconnect configure
+## kconnect config
 
 Set and view your kconnect configuration.
 
@@ -19,7 +19,7 @@ kconnect.
 
 
 ```bash
-kconnect configure [flags]
+kconnect config [flags]
 ```
 
 ### Examples
@@ -27,19 +27,19 @@ kconnect configure [flags]
 ```bash
 
   # Display user's current configurations
-  kconnect configure
+  kconnect config
 
   # Display the user's configurations as json
-  kconnect configure --output json
+  kconnect config --output json
 
   # Set the user's configurations from a local file
-  kconnect configure -f ./defaults.yaml
+  kconnect config -f ./defaults.yaml
 
   # Set the user's configurations from a remote location via HTTP
-  kconnect configure -f https://mycompany.com/config.yaml
+  kconnect config -f https://mycompany.com/config.yaml
 
   # Set the user's configurations from stdin
-  cat ./config.yaml | kconnect configure -f -
+  cat ./config.yaml | kconnect config -f -
 
 ```
 
@@ -47,7 +47,7 @@ kconnect configure [flags]
 
 ```bash
   -f, --file string     File or remote location to use to set the default configuration
-  -h, --help            help for configure
+  -h, --help            help for config
       --output string   Controls the output format for the result. (default "yaml")
 ```
 

--- a/docs/book/src/commands/index.md
+++ b/docs/book/src/commands/index.md
@@ -43,7 +43,7 @@ kconnect [flags]
   #
   # Use this command to set up kconnect the first time you use it on a new system.
   #
-  kconnect configure -f FILE_OR_URL
+  kconnect config -f FILE_OR_URL
 
   # Create a kubectl confirguration context for an AWS EKS cluster.
   #
@@ -84,7 +84,7 @@ kconnect [flags]
 ### SEE ALSO
 
 * [kconnect alias](alias.md)	 - Query and manipulate connection history entry aliases.
-* [kconnect configure](configure.md)	 - Set and view your kconnect configuration.
+* [kconnect config](config.md)	 - Set and view your kconnect configuration.
 * [kconnect logout](logout.md)	 - Logs out of a cluster
 * [kconnect ls](ls.md)	 - Query the user's connection history
 * [kconnect to](to.md)	 - Reconnect to a connection history entry.

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package configure
+package config
 
 import (
 	"fmt"
@@ -44,19 +44,19 @@ kconnect.
 `
 	examples = `
   # Display user's current configurations
-  kconnect configure
+  kconnect config
 
   # Display the user's configurations as json
-  kconnect configure --output json
+  kconnect config --output json
 
   # Set the user's configurations from a local file
-  kconnect configure -f ./defaults.yaml
+  kconnect config -f ./defaults.yaml
 
   # Set the user's configurations from a remote location via HTTP
-  kconnect configure -f https://mycompany.com/config.yaml
+  kconnect config -f https://mycompany.com/config.yaml
 
   # Set the user's configurations from stdin
-  cat ./config.yaml | kconnect configure -f -
+  cat ./config.yaml | kconnect config -f -
 `
 )
 
@@ -64,7 +64,8 @@ func Command() (*cobra.Command, error) {
 	cfg := config.NewConfigurationSet()
 
 	cfgCmd := &cobra.Command{
-		Use:     "configure",
+		Use:     "config",
+		Aliases: []string{"configure"},
 		Short:   shortDesc,
 		Long:    longDesc,
 		Example: examples,

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/fidelity/kconnect/internal/app"
 	"github.com/fidelity/kconnect/internal/commands/alias"
-	"github.com/fidelity/kconnect/internal/commands/configure"
+	configcmd "github.com/fidelity/kconnect/internal/commands/config"
 	"github.com/fidelity/kconnect/internal/commands/logout"
 	"github.com/fidelity/kconnect/internal/commands/ls"
 	"github.com/fidelity/kconnect/internal/commands/to"
@@ -83,7 +83,7 @@ for that cluster.
   #
   # Use this command to set up kconnect the first time you use it on a new system.
   #
-  kconnect configure -f FILE_OR_URL
+  kconnect config -f FILE_OR_URL
 
   # Create a kubectl confirguration context for an AWS EKS cluster.
   #
@@ -174,9 +174,9 @@ func RootCmd() (*cobra.Command, error) {
 		return nil, fmt.Errorf("creating ls command: %w", err)
 	}
 	rootCmd.AddCommand(lsCmd)
-	cfgCmd, err := configure.Command()
+	cfgCmd, err := configcmd.Command()
 	if err != nil {
-		return nil, fmt.Errorf("creating configure command: %w", err)
+		return nil, fmt.Errorf("creating config command: %w", err)
 	}
 	rootCmd.AddCommand(cfgCmd)
 	rootCmd.AddCommand(version.Command())

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -251,7 +251,7 @@ func setupIdpProtocol(cmd *cobra.Command, args []string, params *app.UseParams) 
 	if !hasFlagValue {
 		// If the flag wasn't supplied and we are using a default then
 		// set the value on the commnads flag
-		cmd.Flags().Set("idp-protocol", idpProtocol)
+		cmd.Flags().Set("idp-protocol", idpProtocol) //nolint: errcheck
 	}
 
 	idProvider, err := provider.GetIdentityProvider(idpProtocol)


### PR DESCRIPTION
**What this PR does / why we need it**:
This renames the `configure` command to `config` for consistency with kubectl. An alias has been added to so that `configure` can still be used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #265 