### PR TITLE
feat: detect if running in terminal and added --no-input

### DIFF
--- a/docs/book/src/commands/alias.md
+++ b/docs/book/src/commands/alias.md
@@ -42,8 +42,8 @@ kconnect alias [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/alias_add.md
+++ b/docs/book/src/commands/alias_add.md
@@ -46,8 +46,8 @@ kconnect alias add [flags]
 ```bash
       --config string             Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
       --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --no-input                  Explicitly disable interactivity when running in a terminal
       --no-version-check          If set to true kconnect will not check for a newer version
-      --non-interactive           Run without interactive flag resolution
   -v, --verbosity int             Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/alias_ls.md
+++ b/docs/book/src/commands/alias_ls.md
@@ -48,8 +48,8 @@ kconnect alias ls [flags]
 ```bash
       --config string             Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
       --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --no-input                  Explicitly disable interactivity when running in a terminal
       --no-version-check          If set to true kconnect will not check for a newer version
-      --non-interactive           Run without interactive flag resolution
   -v, --verbosity int             Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/alias_remove.md
+++ b/docs/book/src/commands/alias_remove.md
@@ -51,8 +51,8 @@ kconnect alias remove [flags]
 ```bash
       --config string             Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
       --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --no-input                  Explicitly disable interactivity when running in a terminal
       --no-version-check          If set to true kconnect will not check for a newer version
-      --non-interactive           Run without interactive flag resolution
   -v, --verbosity int             Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/config.md
+++ b/docs/book/src/commands/config.md
@@ -55,8 +55,8 @@ kconnect config [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/index.md
+++ b/docs/book/src/commands/index.md
@@ -76,8 +76,8 @@ kconnect [flags]
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
   -h, --help               help for kconnect
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/logout.md
+++ b/docs/book/src/commands/logout.md
@@ -29,8 +29,8 @@ kconnect logout [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/ls.md
+++ b/docs/book/src/commands/ls.md
@@ -62,8 +62,8 @@ kconnect ls [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/to.md
+++ b/docs/book/src/commands/to.md
@@ -69,8 +69,8 @@ kconnect to [historyid/alias/-/LAST/LAST~N] [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/use.md
+++ b/docs/book/src/commands/use.md
@@ -61,8 +61,8 @@ kconnect use [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/use_aks.md
+++ b/docs/book/src/commands/use_aks.md
@@ -70,8 +70,8 @@ kconnect use aks [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/use_eks.md
+++ b/docs/book/src/commands/use_eks.md
@@ -75,8 +75,8 @@ kconnect use eks [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/use_rancher.md
+++ b/docs/book/src/commands/use_rancher.md
@@ -63,8 +63,8 @@ kconnect use rancher [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/docs/book/src/commands/version.md
+++ b/docs/book/src/commands/version.md
@@ -20,8 +20,8 @@ kconnect version [flags]
 
 ```bash
       --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
       --no-version-check   If set to true kconnect will not check for a newer version
-      --non-interactive    Run without interactive flag resolution
   -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
 ```
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -23,6 +23,11 @@ import (
 	"github.com/fidelity/kconnect/pkg/config"
 )
 
+const (
+	NoInputConfigItem        = "no-input"
+	NonInteractiveConfigItem = "non-interactive"
+)
+
 type HistoryLocationConfig struct {
 	Location string `json:"history-location"`
 }
@@ -82,7 +87,7 @@ func AddKubeconfigConfigItems(cs config.ConfigurationSet) error {
 type CommonConfig struct {
 	ConfigFile          string `json:"config"`
 	Verbosity           int    `json:"verbosity"`
-	Interactive         bool   `json:"non-interactive"`
+	NoInput             bool   `json:"no-input"`
 	DisableVersionCheck bool   `json:"no-version-check"`
 }
 
@@ -93,17 +98,23 @@ func AddCommonConfigItems(cs config.ConfigurationSet) error {
 	if _, err := cs.Int("verbosity", 0, "Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace."); err != nil {
 		return fmt.Errorf("adding verbosity config: %w", err)
 	}
-	if _, err := cs.Bool("non-interactive", false, "Run without interactive flag resolution"); err != nil {
+	if _, err := cs.Bool(NonInteractiveConfigItem, false, "Run without interactive flag resolution"); err != nil {
 		return fmt.Errorf("adding non-interactive config: %w", err)
+	}
+	if _, err := cs.Bool(NoInputConfigItem, false, "Explicitly disable interactivity when running in a terminal"); err != nil {
+		return fmt.Errorf("adding no-input config: %w", err)
 	}
 	if _, err := cs.Bool("no-version-check", false, "If set to true kconnect will not check for a newer version"); err != nil {
 		return fmt.Errorf("adding non-version-check config: %w", err)
 	}
-	cs.SetShort("verbosity", "v")           //nolint
-	cs.SetHistoryIgnore("config")           //nolint
-	cs.SetHistoryIgnore("verbosity")        //nolint
-	cs.SetHistoryIgnore("non-interactive")  //nolint
-	cs.SetHistoryIgnore("no-version-check") //nolint
+	cs.SetShort("verbosity", "v")                                       //nolint
+	cs.SetHistoryIgnore("config")                                       //nolint
+	cs.SetHistoryIgnore("verbosity")                                    //nolint
+	cs.SetHistoryIgnore(NonInteractiveConfigItem)                       //nolint
+	cs.SetHistoryIgnore(NoInputConfigItem)                              //nolint
+	cs.SetHistoryIgnore("no-version-check")                             //nolint
+	cs.SetDeprecated(NonInteractiveConfigItem, "please use --no-input") //nolint
+
 	return nil
 }
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -112,7 +112,7 @@ for that cluster.
 )
 
 // RootCmd creates the root kconnect command
-func RootCmd() (*cobra.Command, error) {
+func RootCmd() (*cobra.Command, error) { //nolint: funlen
 	cfg = config.NewConfigurationSet()
 
 	rootCmd := &cobra.Command{
@@ -127,7 +127,18 @@ func RootCmd() (*cobra.Command, error) {
 					err.Error())
 			}
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			inTerminal := isRunningInTerminal()
+			if !inTerminal {
+				zap.S().Debug("Not running in a terminal, setting no-input to true")
+				cmd.Flags().Set(app.NoInputConfigItem, "true") //nolint: errcheck
+				return nil
+			}
+
+			if err := flags.CopyFlagValue(app.NonInteractiveConfigItem, app.NoInputConfigItem, cmd.Flags(), true); err != nil {
+				return fmt.Errorf("copying flag value from %s to %s: %w", app.NonInteractiveConfigItem, app.NoInputConfigItem, err)
+			}
+
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
@@ -220,6 +231,14 @@ func ensureAppDirectory() error {
 	}
 
 	return nil
+}
+
+func isRunningInTerminal() bool {
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+		return true
+	}
+
+	return false
 }
 
 func reportNewerVersion() error {

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -272,11 +272,8 @@ func setupIdpProtocol(cmd *cobra.Command, args []string, params *app.UseParams) 
 }
 
 func preRun(params *app.UseParams) error {
-	// Update the context now the flags have been parsed
-	interactive := isInteractive(params.Context.ConfigurationItems())
-
 	params.Context = provider.NewContext(
-		provider.WithInteractive(interactive),
+		provider.WithInteractive(!params.NoInput),
 		provider.WithConfig(params.Context.ConfigurationItems()),
 	)
 
@@ -322,17 +319,6 @@ func isIdpSupported(idProviderName string, clusterprovider provider.ClusterProvi
 	}
 
 	return false
-}
-
-func isInteractive(cs config.ConfigurationSet) bool {
-	item := cs.Get("non-interactive")
-	if item == nil {
-		return true
-	}
-
-	value := item.Value.(bool)
-
-	return !value
 }
 
 func ensureConfigFolder(path string) error {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -165,3 +165,20 @@ func GetFlagValueDirect(args []string, longName, shortName string) (string, erro
 	// look in app config
 	return config.GetValue(longName, "")
 }
+
+func CopyFlagValue(sourceFlagName, destinationFlagName string, fs *pflag.FlagSet, ignoreNotFound bool) error {
+	sourceFlag := fs.Lookup(sourceFlagName)
+	if sourceFlag == nil && !ignoreNotFound {
+		return fmt.Errorf("getting source flag %s: %w", sourceFlagName, ErrFlagNotFound)
+	}
+	destinationFlag := fs.Lookup(destinationFlagName)
+	if destinationFlag == nil && !ignoreNotFound {
+		return fmt.Errorf("getting destination flag %s: %w", destinationFlagName, ErrFlagNotFound)
+	}
+
+	if sourceFlag != nil && sourceFlag.Changed && destinationFlag != nil {
+		destinationFlag.Value = sourceFlag.Value
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If not running in a terminal then --no-input is set automatically.

Added --no-input to disable interactivity and deprecated --non-interactive to make kconnect more consistent with other clis.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #267 