### PR TITLE
feat: kubectl plugin help messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v48.2.2+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.15
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.5
-	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c // indirect
@@ -54,7 +53,6 @@ require (
 	golang.org/x/tools v0.0.0-20201103235415-b653051172e4 // indirect
 	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/api v0.19.1 // indirect
 	k8s.io/apimachinery v0.19.1
 	k8s.io/cli-runtime v0.19.1
 	k8s.io/client-go v0.19.1

--- a/internal/commands/alias/add.go
+++ b/internal/commands/alias/add.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 const (
@@ -40,23 +41,23 @@ the alias instead of the connection history entry's unique ID.
 `
 	examplesAdd = `
   # Add an alias to a connection history entry
-  kconnect alias add --id 01EMEM5DB60TMX7D8SS2JCX3MT --alias dev-bu-1
+  {{.CommandPath}} alias add --id 01EMEM5DB60TMX7D8SS2JCX3MT --alias dev-bu-1
 
   # Connect to a cluster using the alias
-  kconnect to dev-bu-1
+  {{.CommandPath}} to dev-bu-1
 
   # List available aliases
-  kconnect alias ls
+  {{.CommandPath}} alias ls
 
   # List available history entries - includes aliases
-  kconnect ls
+  {{.CommandPath}} ls
 `
 )
 
 func addCommand() (*cobra.Command, error) { //nolint: dupl
 	cfg := config.NewConfigurationSet()
 
-	lsCmd := &cobra.Command{
+	addCmd := &cobra.Command{
 		Use:     "add",
 		Short:   shortDescAdd,
 		Long:    longDescAdd,
@@ -97,16 +98,17 @@ func addCommand() (*cobra.Command, error) { //nolint: dupl
 			return a.AliasAdd(ctx, params)
 		},
 	}
+	utils.FormatCommand(addCmd)
 
 	if err := addConfigAdd(cfg); err != nil {
 		return nil, fmt.Errorf("adding add command config: %w", err)
 	}
 
-	if err := flags.CreateCommandFlags(lsCmd, cfg); err != nil {
+	if err := flags.CreateCommandFlags(addCmd, cfg); err != nil {
 		return nil, err
 	}
 
-	return lsCmd, nil
+	return addCmd, nil
 
 }
 

--- a/internal/commands/alias/alias.go
+++ b/internal/commands/alias/alias.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fidelity/kconnect/internal/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 const (
@@ -39,13 +40,13 @@ connection history entries.
 `
 	examples = `
   # Add an alias to an existing connection history entry
-  kconnect alias add --id 123456 --alias appdev
+  {{.CommandPath}} alias add --id 123456 --alias appdev
 
   # List available connection history entry aliases
-  kconnect alias ls
+  {{.CommandPath}} alias ls
 
   # Remove an alias from a connection history entry
-  kconnect alias remove --alias appdev
+  {{.CommandPath}} alias remove --alias appdev
 `
 )
 
@@ -65,6 +66,7 @@ func Command() (*cobra.Command, error) {
 			}
 		},
 	}
+	utils.FormatCommand(aliasCmd)
 
 	if err := addConfigRoot(cfg); err != nil {
 		return nil, fmt.Errorf("add command config: %w", err)

--- a/internal/commands/alias/ls.go
+++ b/internal/commands/alias/ls.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 var (
@@ -40,19 +41,19 @@ An alias is a user-friendly name for a connection history entry.
 `
 	examplesLs = `
   # Display all the aliases as a table
-  kconnect alias ls
+  {{.CommandPath}} alias ls
 
   # Display all connection history entry aliases as a table
-  kconnect alias ls
+  {{.CommandPath}} alias ls
 
   # Display all connection history entry aliases as json
-  kconnect alias ls --output json
+  {{.CommandPath}} alias ls --output json
 
   # Connect to a cluster using a connection history entry alias
-  kconnect to ${alias}
+  {{.CommandPath}} to ${alias}
 
   # List all connection history entries as a table - includes aliases
-  kconnect ls
+  {{.CommandPath}} ls
 `
 )
 
@@ -100,6 +101,7 @@ func lsCommand() (*cobra.Command, error) { //nolint: dupl
 			return a.AliasList(ctx, params)
 		},
 	}
+	utils.FormatCommand(lsCmd)
 
 	if err := addConfigLs(cfg); err != nil {
 		return nil, fmt.Errorf("add ls command config: %w", err)

--- a/internal/commands/alias/remove.go
+++ b/internal/commands/alias/remove.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 var (
@@ -35,32 +36,31 @@ var (
 	longDescRemove  = `
 Remove an alias from a single connection history entry by the entry ID or the 
 alias.
-
 Set the --all flag on this command to remove all connection history aliases from
 the user's connection history.
 `
 	examplesRemove = `
   # Remove an alias using the alias name
-  kconnect alias remove --alias dev-bu-1
+  {{.CommandPath}} alias remove --alias dev-bu-1
 
   # Remove an alias using a histiry entry id
-  kconnect alias remove --id 01EMEM5DB60TMX7D8SS2JCX3MT
+  {{.CommandPath}} alias remove --id 01EMEM5DB60TMX7D8SS2JCX3MT
 
   # Remove all aliases
-  kconnect alias remove --all
+  {{.CommandPath}} alias remove --all
 
   # List available aliases
-  kconnect alias ls
+  {{.CommandPath}} alias ls
 
   # Query your connection history - includes aliases
-  kconnect ls
+  {{.CommandPath}} ls
 `
 )
 
 func removeCommand() (*cobra.Command, error) { //nolint: dupl
 	cfg := config.NewConfigurationSet()
 
-	lsCmd := &cobra.Command{
+	rmCmd := &cobra.Command{
 		Use:     "remove",
 		Short:   shortDescRemove,
 		Long:    longDescRemove,
@@ -101,16 +101,17 @@ func removeCommand() (*cobra.Command, error) { //nolint: dupl
 			return a.AliasRemove(ctx, params)
 		},
 	}
+	utils.FormatCommand(rmCmd)
 
 	if err := addConfigRemove(cfg); err != nil {
 		return nil, fmt.Errorf("add remove command config: %w", err)
 	}
 
-	if err := flags.CreateCommandFlags(lsCmd, cfg); err != nil {
+	if err := flags.CreateCommandFlags(rmCmd, cfg); err != nil {
 		return nil, err
 	}
 
-	return lsCmd, nil
+	return rmCmd, nil
 
 }
 

--- a/internal/commands/alias/remove.go
+++ b/internal/commands/alias/remove.go
@@ -36,6 +36,7 @@ var (
 	longDescRemove  = `
 Remove an alias from a single connection history entry by the entry ID or the 
 alias.
+
 Set the --all flag on this command to remove all connection history aliases from
 the user's connection history.
 `

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 const (
@@ -47,16 +48,16 @@ kconnect.
   kconnect config
 
   # Display the user's configurations as json
-  kconnect config --output json
+  {{.CommandPath}} config --output json
 
   # Set the user's configurations from a local file
-  kconnect config -f ./defaults.yaml
+  {{.CommandPath}} config -f ./defaults.yaml
 
   # Set the user's configurations from a remote location via HTTP
-  kconnect config -f https://mycompany.com/config.yaml
+  {{.CommandPath}} config -f https://mycompany.com/config.yaml
 
   # Set the user's configurations from stdin
-  cat ./config.yaml | kconnect config -f -
+  cat ./config.yaml | {{.CommandPath}} config -f -
 `
 )
 
@@ -95,6 +96,7 @@ func Command() (*cobra.Command, error) {
 			return a.Configuration(ctx, params)
 		},
 	}
+	utils.FormatCommand(cfgCmd)
 
 	if err := addConfig(cfg); err != nil {
 		return nil, fmt.Errorf("add command config: %w", err)

--- a/internal/commands/logout/logout.go
+++ b/internal/commands/logout/logout.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -79,6 +80,7 @@ func Command() (*cobra.Command, error) {
 			return a.Logout(params)
 		},
 	}
+	utils.FormatCommand(logoutCmd)
 
 	if err := addConfig(cfg); err != nil {
 		return nil, fmt.Errorf("add command config: %w", err)

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 var (
@@ -35,7 +36,6 @@ var (
 	longDesc  = `
 Query and display the user's connection history entries, including entry IDs and
 aliases.
-
 Each time kconnect creates a new kubectl context to connect to a Kubernetes 
 cluster, it saves the settings for the new connection as an entry in the user's 
 connection history.  The user can then reconnect using those same settings later 
@@ -43,22 +43,22 @@ via the connection history entry's ID or alias.
 `
 	examples = `
   # Display all connection history entries as a table
-  kconnect ls
+  {{.CommandPath}} ls
 
   # Display all connection history entries as YAML
-  kconnect ls --output yaml
+  {{.CommandPath}} ls --output yaml
 
   # Display a specific connection history entry by entry id
-  kconnect ls --id 01EM615GB2YX3C6WZ9MCWBDWBF
+  {{.CommandPath}} ls --id 01EM615GB2YX3C6WZ9MCWBDWBF
 
   # Display a specific connection history entry by its alias
-  kconnect ls --alias mydev
+  {{.CommandPath}} ls --alias mydev
 
   # Display all connection history entries for the EKS mamaged cluster provider
-  kconnect ls --cluster-provider eks
+  {{.CommandPath}} ls --cluster-provider eks
 
   # Reconnect using the connection history entry alias
-  kconnect to mydev
+  {{.CommandPath}} to mydev
 `
 )
 
@@ -106,6 +106,7 @@ func Command() (*cobra.Command, error) {
 			return a.QueryHistory(ctx, params)
 		},
 	}
+	utils.FormatCommand(lsCmd)
 
 	if err := addConfig(cfg); err != nil {
 		return nil, fmt.Errorf("add command config: %w", err)

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -36,6 +36,7 @@ var (
 	longDesc  = `
 Query and display the user's connection history entries, including entry IDs and
 aliases.
+
 Each time kconnect creates a new kubectl context to connect to a Kubernetes 
 cluster, it saves the settings for the new connection as an entry in the user's 
 connection history.  The user can then reconnect using those same settings later 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -172,39 +172,10 @@ func RootCmd() (*cobra.Command, error) {
 	rootCmd.PersistentFlags().AddFlagSet(rootFlags)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
-	useCmd, err := use.Command()
+	err = addRootCommands(rootCmd)
 	if err != nil {
-		return nil, fmt.Errorf("creating use command: %w", err)
+		return nil, fmt.Errorf("adding commands: %w", err)
 	}
-	rootCmd.AddCommand(useCmd)
-	toCmd, err := to.Command()
-	if err != nil {
-		return nil, fmt.Errorf("creating to command: %w", err)
-	}
-	rootCmd.AddCommand(toCmd)
-	lsCmd, err := ls.Command()
-	if err != nil {
-		return nil, fmt.Errorf("creating ls command: %w", err)
-	}
-	rootCmd.AddCommand(lsCmd)
-	cfgCmd, err := configcmd.Command()
-	if err != nil {
-		return nil, fmt.Errorf("creating config command: %w", err)
-	}
-	rootCmd.AddCommand(cfgCmd)
-	rootCmd.AddCommand(version.Command())
-
-	aliasCmd, err := alias.Command()
-	if err != nil {
-		return nil, fmt.Errorf("creating alias command: %w", err)
-	}
-	rootCmd.AddCommand(aliasCmd)
-
-	logoutCmd, err := logout.Command()
-	if err != nil {
-		return nil, fmt.Errorf("creating logout command: %w", err)
-	}
-	rootCmd.AddCommand(logoutCmd)
 
 	cobra.OnInitialize(initConfig)
 
@@ -214,6 +185,43 @@ func RootCmd() (*cobra.Command, error) {
 func initConfig() {
 	viper.SetEnvPrefix("KCONNECT")
 	viper.AutomaticEnv()
+}
+
+func addRootCommands(rootCmd *cobra.Command) error {
+	useCmd, err := use.Command()
+	if err != nil {
+		return fmt.Errorf("creating use command: %w", err)
+	}
+	rootCmd.AddCommand(useCmd)
+	toCmd, err := to.Command()
+	if err != nil {
+		return fmt.Errorf("creating to command: %w", err)
+	}
+	rootCmd.AddCommand(toCmd)
+	lsCmd, err := ls.Command()
+	if err != nil {
+		return fmt.Errorf("creating ls command: %w", err)
+	}
+	rootCmd.AddCommand(lsCmd)
+	cfgCmd, err := configcmd.Command()
+	if err != nil {
+		return fmt.Errorf("creating config command: %w", err)
+	}
+	rootCmd.AddCommand(cfgCmd)
+	rootCmd.AddCommand(version.Command())
+
+	aliasCmd, err := alias.Command()
+	if err != nil {
+		return fmt.Errorf("creating alias command: %w", err)
+	}
+	rootCmd.AddCommand(aliasCmd)
+
+	logoutCmd, err := logout.Command()
+	if err != nil {
+		return fmt.Errorf("creating logout command: %w", err)
+	}
+	rootCmd.AddCommand(logoutCmd)
+	return nil
 }
 
 func ensureAppDirectory() error {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -43,6 +43,7 @@ import (
 	appver "github.com/fidelity/kconnect/internal/version"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 var (
@@ -75,51 +76,51 @@ can then display their connection history entries and reconnect to any entry by
 its unique ID (or by a user-friendly alias) to refresh an expired access token
 for that cluster.
 `
-	examples = `
+	examplesTemplate = `
   # Display a help screen with kconnect commands.
-  kconnect help
+  {{.CommandPath}} help
 
   # Configure the default identity provider and connection profile for your user.
   #
   # Use this command to set up kconnect the first time you use it on a new system.
   #
-  kconnect config -f FILE_OR_URL
+  {{.CommandPath}} config -f FILE_OR_URL
 
   # Create a kubectl confirguration context for an AWS EKS cluster.
   #
   # Use this command the first time you connect to a new cluster or a new context.
   #
-  kconnect use eks
+  {{.CommandPath}} use eks
 
   # Display connection history entries.
   #
-  kconnect ls
+  {{.CommandPath}} ls
 
   # Add an alias to a connection history entry.
   #
-  kconnect alias add --id 012EX456834AFXR0F2NZT68RPKD --alias MYALIAS
+  {{.CommandPath}} alias add --id 012EX456834AFXR0F2NZT68RPKD --alias MYALIAS
 
   # Reconnect and refresh the token for an aliased connection history entry.
   #
   # Use this to reconnect to a provider and refresh an expired access token.
   #
-  kconnect to MYALIAS
+  {{.CommandPath}} to MYALIAS
 
   # Display connection history entry aliases.
   #
-  kconnect alias ls
+  {{.CommandPath}} alias ls
 `
 )
 
 // RootCmd creates the root kconnect command
-func RootCmd() (*cobra.Command, error) { //nolint: funlen
+func RootCmd() (*cobra.Command, error) {
 	cfg = config.NewConfigurationSet()
 
 	rootCmd := &cobra.Command{
 		Use:     "kconnect",
 		Short:   shortDesc,
 		Long:    longDesc,
-		Example: examples,
+		Example: examplesTemplate,
 		Run: func(c *cobra.Command, _ []string) {
 			if err := c.Help(); err != nil {
 				zap.S().Debugw("ingoring cobra error",
@@ -155,6 +156,7 @@ func RootCmd() (*cobra.Command, error) { //nolint: funlen
 			return nil
 		},
 	}
+	utils.FormatCommand(rootCmd)
 
 	if err := ensureAppDirectory(); err != nil {
 		return nil, fmt.Errorf("ensuring app directory exists: %w", err)

--- a/internal/commands/to/to.go
+++ b/internal/commands/to/to.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 var (
@@ -54,27 +55,27 @@ Otherwise kconnect will promot the user to enter their password.
 `
 	examples = `
   # Reconnect based on an alias - aliases can be found using kconnect ls
-  kconnect to uat-bu1
+  {{.CommandPath}} to uat-bu1
 
   # Reconnect based on an history id - history id can be found using kconnect ls
-  kconnect to 01EM615GB2YX3C6WZ9MCWBDWBF
+  {{.CommandPath}} to 01EM615GB2YX3C6WZ9MCWBDWBF
 
   # Reconnect interactively from history list
-  kconnect to
+  {{.CommandPath}} to
 
   # Reconnect to current cluster (this is useful for renewing credentials)
-  kconnect to -
+  {{.CommandPath}} to -
   OR
-  kconnect to LAST
+  {{.CommandPath}} to LAST
 
   # Reconnect to cluster used before current one
-  kconnect to LAST~1
+  {{.CommandPath}} to LAST~1
 
   # Reconnect based on an alias supplying a password
-  kconnect to uat-bu1 --password supersecret
+  {{.CommandPath}} to uat-bu1 --password supersecret
 
   # Reconnect based on an alias supplying a password via env var
-  KCONNECT_PASSWORD=supersecret kconnect to uat-bu2
+  KCONNECT_PASSWORD=supersecret {{.CommandPath}} to uat-bu2
  `
 )
 
@@ -124,6 +125,7 @@ func Command() (*cobra.Command, error) {
 			return a.ConnectTo(params)
 		},
 	}
+	utils.FormatCommand(toCmd)
 
 	if err := addConfig(cfg); err != nil {
 		return nil, fmt.Errorf("add command config: %w", err)

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -32,6 +32,7 @@ import (
 	"github.com/fidelity/kconnect/pkg/history"
 	"github.com/fidelity/kconnect/pkg/history/loader"
 	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 var (
@@ -77,17 +78,17 @@ specified cluster provider.
 `
 	usageExample = `
   # Connect to EKS and choose an available EKS cluster.
-  kconnect use eks
+  {{.CommandPath}} use eks
 
   # Connect to an EKS cluster and create an alias for its connection history entry.
-  kconnect use eks --alias mycluster
+  {{.CommandPath}} use eks --alias mycluster
 `
 	usageExampleFoot = `
   # Reconnect to a cluster by its connection history entry alias.
-  kconnect to mycluster
+  {{.CommandPath}} to mycluster
 
   # Display the user's connection history as a table.
-  kconnect ls
+  {{.CommandPath}} ls
 `
 )
 
@@ -105,6 +106,8 @@ func Command() (*cobra.Command, error) {
 			}
 		},
 	}
+
+	utils.FormatCommand(useCmd)
 
 	// Add the provider subcommands
 	for _, provider := range provider.ListClusterProviders() {
@@ -196,6 +199,7 @@ func createProviderCmd(clusterProvider provider.ClusterProvider) (*cobra.Command
 
 	providerCmd.SetUsageFunc(providerUsage(clusterProvider.Name()))
 
+	utils.FormatCommand(providerCmd)
 	return providerCmd, nil
 }
 
@@ -343,7 +347,8 @@ func ensureConfigFolder(path string) error {
 
 func providerUsage(providerName string) func(cmd *cobra.Command) error {
 	return func(cmd *cobra.Command) error {
-		usage := []string{fmt.Sprintf("Usage: %s", cmd.UseLine())}
+		use := utils.FormatUse(cmd.UseLine())
+		usage := []string{fmt.Sprintf("Usage: %s", use)}
 
 		if cmd.Example != "" {
 			usage = append(usage, "\nExamples:")

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/fidelity/kconnect/internal/version"
+	"github.com/fidelity/kconnect/pkg/utils"
 )
 
 // Command creates the version cobra command
@@ -34,6 +35,7 @@ func Command() *cobra.Command {
 			return doVersion(cmd)
 		},
 	}
+	utils.FormatCommand(versionCmd)
 
 	return versionCmd
 }

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -114,12 +114,12 @@ func (p *eksClusterProvider) ensureLogger() {
 func (p *eksClusterProvider) UsageExample() string {
 	return `
   # Discover EKS clusters using SAML
-  kconnect use eks --idp-protocol saml
+  {{.CommandPath}} use eks --idp-protocol saml
 
   # Discover EKS clusters using SAML with a specific role
-  kconnect use eks --idp-protocol saml --role-arn arn:aws:iam::000000000000:role/KubernetesAdmin
+  {{.CommandPath}} use eks --idp-protocol saml --role-arn arn:aws:iam::000000000000:role/KubernetesAdmin
 
   # Discover an EKS cluster and add an alias to its connection history entry
-  kconnect use eks --alias mycluster
+  {{.CommandPath}} use eks --alias mycluster
 `
 }

--- a/pkg/plugins/discovery/azure/provider.go
+++ b/pkg/plugins/discovery/azure/provider.go
@@ -121,12 +121,12 @@ func (p *aksClusterProvider) ensureLogger() {
 // UsageExample will provide an example of the usage of this provider
 func (p *aksClusterProvider) UsageExample() string {
 	return `  # Discover AKS clusters using Azure AD
-  kconnect use aks --idp-protocol aad
+  {{.CommandPath}} use aks --idp-protocol aad
 
   # Discover AKS clusters using file based credentials
   export AZURE_TENANT_ID="123455"
   export AZURE_CLIENT_ID="76849"
   export AZURE_CLIENT_SECRET="supersecret"
-  kconnect use aks --idp-protocol az-env
+  {{.CommandPath}} use aks --idp-protocol az-env
 `
 }

--- a/pkg/plugins/discovery/rancher/provider.go
+++ b/pkg/plugins/discovery/rancher/provider.go
@@ -97,9 +97,9 @@ func (p *rancherClusterProvider) ensureLogger() {
 // UsageExample will provide an example of the usage of this provider
 func (p *rancherClusterProvider) UsageExample() string {
 	return `  # Discover Rancher clusters using Active Directory
-  kconnect use rancher --idp-protocol rancher-ad
+  {{.CommandPath}} use rancher --idp-protocol rancher-ad
 
   # Discover clusters via Rancher using a API key
-  kconnect use rancher --idp-protocol static-token --token ABCDEF
+  {{.CommandPath}} use rancher --idp-protocol static-token --token ABCDEF
 `
 }

--- a/pkg/utils/command.go
+++ b/pkg/utils/command.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The kconnect Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func FormatCommand(cmd *cobra.Command) {
+
+	rootCmdName := "kconnect"
+	// If running as a krew plugin, need to change usage output
+	if isKrewPlugin() {
+		rootCmdName = "kubectl connect"
+		// Only change this for root command
+		if cmd.Use == "kconnect" {
+			cmd.Use = "connect"
+		}
+		cmd.SetUsageTemplate(strings.NewReplacer(
+			"{{.UseLine}}", "kubectl {{.UseLine}}",
+			"{{.CommandPath}}", "kubectl {{.CommandPath}}").Replace(cmd.UsageTemplate()))
+	}
+	cmd.Example = formatMessage(cmd.Example, rootCmdName)
+}
+
+func FormatUse(use string) string {
+	if isKrewPlugin() {
+		return "kubectl " + use
+	}
+	return use
+}
+
+func isKrewPlugin() bool {
+	return strings.HasPrefix(filepath.Base(os.Args[0]), "kubectl-")
+}
+
+func formatMessage(message, rootCmdName string) string {
+	return strings.NewReplacer("{{.CommandPath}}", rootCmdName).Replace(message)
+}

--- a/pkg/utils/filter.go
+++ b/pkg/utils/filter.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2020 The kconnect Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Formats help messages correctly when running an a kubectl plugin

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #225 