### PR TITLE
feat: adding kubelogin support to AKS provider

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,7 @@ brews:
     description: "Kubernetes Connection Manager CLI"
     dependencies:
       - aws-iam-authenticator
+      - Azure/kubelogin/kubelogin
       - kubernetes-cli
     folder: Formula
 

--- a/docs/book/src/commands/use_aks.md
+++ b/docs/book/src/commands/use_aks.md
@@ -28,14 +28,14 @@ kconnect use aks [flags]
 
 ```bash
   # Discover AKS clusters using Azure AD
-	kconnect use aks --idp-protocol aad
+  kconnect use aks --idp-protocol aad
 
-	# Discover AKS clusters using file based credentials
-	export AZURE_TENANT_ID="123455"
-	export AZURE_CLIENT_ID="76849"
-	export AZURE_CLIENT_SECRET="supersecret"
-	kconnect use aks --idp-protocol az-env
-  
+  # Discover AKS clusters using file based credentials
+  export AZURE_TENANT_ID="123455"
+  export AZURE_CLIENT_ID="76849"
+  export AZURE_CLIENT_SECRET="supersecret"
+  kconnect use aks --idp-protocol az-env
+
   # Reconnect to a cluster by its connection history entry alias.
   kconnect to mycluster
 
@@ -49,12 +49,14 @@ kconnect use aks [flags]
 ```bash
       --admin                      Generate admin user kubeconfig
   -a, --alias string               Friendly name to give to give the connection
+      --azure-env string           The Azure environment the clusters are in. Possible values: public,china,usgov,stack (default "public")
   -c, --cluster-id string          Id of the cluster to use.
       --cluster-name string        The name of the AKS cluster
   -h, --help                       help for aks
       --history-location string    Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
       --idp-protocol string        The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.
   -k, --kubeconfig string          Location of the kubeconfig to use. (default "$HOME/.kube/config")
+      --login-type string          The login method to use when connecting to the AKS cluster as a non-admin. Possible values: devicecode,spn,ropc,msi (default "devicecode")
       --max-history int            Sets the maximum number of history items to keep (default 100)
   -n, --namespace string           Sets namespace for context in kubeconfig
       --no-history                 If set to true then no history entry will be written

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -6,7 +6,9 @@ Once you have [installed](installation.md) kconnect you can see a list of the co
 kconnect help
 ```
 
-<em>NOTE:</em> `kconnect` requires [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) to authenticate to the AWS EKS cluster provider.
+<em>NOTE:</em> `kconnect` requires:
+* [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) to authenticate to AWS EKS clusters.
+* [kubelogin](https://github.com/Azure/kubelogin) to authenticate to Azure AKS clusters.
 
 The general workflow for using kconnect is the following:
 

--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -9,6 +9,8 @@
 
 <em>NOTE:</em> `kconnect` requires [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) to authenticate to the AWS EKS cluster provider.
 
+<em>NOTE:</em> `kconnect` requires [kubelogin](https://github.com/Azure/kubelogin) to authenticate to Azure AKS clusters.
+
 
 ## kubectl plugin
 

--- a/pkg/plugins/discovery/azure/defaults.go
+++ b/pkg/plugins/discovery/azure/defaults.go
@@ -25,4 +25,6 @@ const (
 	ResourceGroupConfigItem    = "resource-group"
 	AdminConfigItem            = "admin"
 	ClusterNameConfigItem      = "cluster-name"
+	LoginTypeConfigItem        = "login-type"
+	AzureEnvironmentConfigItem = "azure-env"
 )

--- a/pkg/plugins/discovery/azure/discover.go
+++ b/pkg/plugins/discovery/azure/discover.go
@@ -72,10 +72,23 @@ func (p *aksClusterProvider) listClusters(ctx context.Context) ([]*discovery.Clu
 			if err != nil {
 				return nil, fmt.Errorf("create cluster id: %w", err)
 			}
+
 			cluster := &discovery.Cluster{
 				Name: *val.Name,
 				ID:   clusterID,
 			}
+
+			controlPlaneEndpoint := ""
+			if val.Fqdn != nil {
+				controlPlaneEndpoint = fmt.Sprintf("https://%s:443", *val.Fqdn)
+			}
+			if val.PrivateFQDN != nil {
+				controlPlaneEndpoint = fmt.Sprintf("https://%s:443", *val.PrivateFQDN)
+			}
+			if controlPlaneEndpoint != "" {
+				cluster.ControlPlaneEndpoint = &controlPlaneEndpoint
+			}
+
 			clusters = append(clusters, cluster)
 		}
 	}

--- a/pkg/plugins/discovery/azure/types.go
+++ b/pkg/plugins/discovery/azure/types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+// Environment is a type that represents an Azure environment
+type Environment string
+
+var (
+	// EnvironmentPublicCloud is the general Azure public cloud
+	EnvironmentPublicCloud = Environment("public")
+	// EnvironmentChinaCloud is the public Azure cloud in China
+	EnvironmentChinaCloud = Environment("china")
+	// EnvironmentUSGovCloud is the US Government specific Azure cloud
+	EnvironmentUSGovCloud = Environment("usgov")
+	// EnvironmentStackCloud is the Azure stack cloud
+	EnvironmentStackCloud = Environment("stack")
+)
+
+// LoginType is a type that denotes the type of user login
+type LoginType string
+
+var (
+	// LoginTypeDeviceCode is for using a device code to login
+	LoginTypeDeviceCode = LoginType("devicecode")
+	// LoginTypeServicePrincipal is for using a service principal to login
+	LoginTypeServicePrincipal = LoginType("spn")
+	// LoginTypeResourceOwnerPassword is for using the resource owner password type
+	LoginTypeResourceOwnerPassword = LoginType("ropc")
+	// LoginTypeManagedServiceIdentity is for using the managed service identity to login
+	LoginTypeManagedServiceIdentity = LoginType("msi")
+)

--- a/pkg/utils/prerequisites.go
+++ b/pkg/utils/prerequisites.go
@@ -63,3 +63,13 @@ func CheckAWSIAMAuthPrereq() error {
 	}
 	return nil
 }
+
+func CheckKubeloginPrereq() error {
+
+	cmd := exec.Command("kubelogin")
+	_, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("error finding kubelogin: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds kubelogin to the kubeconfig generation for non-admin users.

**Still work in progress**

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #281 