### PR TITLE
feat: add history rm command

### DIFF
--- a/docs/book/src/commands/history.md
+++ b/docs/book/src/commands/history.md
@@ -50,6 +50,7 @@ kconnect history [flags]
 * [kconnect](index.md)	 - The Kubernetes Connection Manager CLI
 * [kconnect history export](history_export.md)	 - Export history to an external file
 * [kconnect history import](history_import.md)	 - Import history from an external file
+* [kconnect history rm](history_rm.md)	 - Remove history entries
 
 
 > NOTE: this page is auto-generated from the cobra commands

--- a/docs/book/src/commands/history_rm.md
+++ b/docs/book/src/commands/history_rm.md
@@ -1,0 +1,59 @@
+## kconnect history rm
+
+Remove history entries
+
+### Synopsis
+
+
+Allows users to delete history entries from their history
+
+
+```bash
+kconnect history rm [flags]
+```
+
+### Examples
+
+```bash
+
+  # Display history entries
+  kconnect ls
+  
+  # Delete a history entry with specific ID
+  kconnect history rm 01exm3ty400w9sr28jawc8fkae
+  
+  # Delete multiple history entries with specific IDs
+  kconnect history rm 01exm3ty400w9sr28jawc8fkae 01exm3tvw2f5snkj18rk1ngmyb
+
+  # Delete all history entries
+  kconnect history rm --all
+  
+  # Delete all history entries that match the filter (e.g. alias that have "prod" in them)
+  kconnect history rm --filter alias=*prod*
+
+```
+
+### Options
+
+```bash
+      --all             remove all entries
+      --filter string   filter to apply to import. Can specify multiple filters by using commas, and supports wilcards (*)
+  -h, --help            help for rm
+```
+
+### Options inherited from parent commands
+
+```bash
+      --config string             Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --no-input                  Explicitly disable interactivity when running in a terminal
+      --no-version-check          If set to true kconnect will not check for a newer version
+  -v, --verbosity int             Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
+```
+
+### SEE ALSO
+
+* [kconnect history](history.md)	 - Import and export history
+
+
+> NOTE: this page is auto-generated from the cobra commands

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-playground/validator/v10 v10.3.0
 	github.com/golang/mock v1.3.1
 	github.com/golangci/golangci-lint v1.31.0 // indirect
+	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -219,3 +219,18 @@ func AddHistoryExportConfig(cs config.ConfigurationSet) error {
 	}
 	return nil
 }
+
+type HistoryRemoveConfig struct {
+	All    bool   `json:"all,omitempty"`
+	Filter string `json:"filter,omitempty"`
+}
+
+func AddHistoryRemoveConfig(cs config.ConfigurationSet) error {
+	if _, err := cs.String("filter", "", "filter to apply to import. Can specify multiple filters by using commas, and supports wilcards (*)"); err != nil {
+		return fmt.Errorf("adding filter config: %w", err)
+	}
+	if _, err := cs.Bool("all", false, "remove all entries"); err != nil {
+		return fmt.Errorf("adding all config: %w", err)
+	}
+	return nil
+}

--- a/internal/commands/history/history.go
+++ b/internal/commands/history/history.go
@@ -88,6 +88,12 @@ func Command() (*cobra.Command, error) {
 	}
 	historyCmd.AddCommand(exportCmd)
 
+	rmCmd, err := rmCommand()
+	if err != nil {
+		return nil, fmt.Errorf("creating history rm command: %w", err)
+	}
+	historyCmd.AddCommand(rmCmd)
+
 	return historyCmd, nil
 
 }

--- a/internal/commands/history/rm.go
+++ b/internal/commands/history/rm.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package history
+
+import (
+	"fmt"
+
+	"github.com/fidelity/kconnect/internal/app"
+	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/fidelity/kconnect/pkg/history"
+	"github.com/fidelity/kconnect/pkg/history/loader"
+	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/utils"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+const (
+	shortDescRm = "Remove history entries"
+	longDescRm  = `
+Allows users to delete history entries from their history
+`
+	examplesRm = `
+  # Display history entries
+  {{.CommandPath}} ls
+  
+  # Delete a history entry with specific ID
+  {{.CommandPath}} history rm 01exm3ty400w9sr28jawc8fkae
+  
+  # Delete multiple history entries with specific IDs
+  {{.CommandPath}} history rm 01exm3ty400w9sr28jawc8fkae 01exm3tvw2f5snkj18rk1ngmyb
+
+  # Delete all history entries
+  {{.CommandPath}} history rm --all
+  
+  # Delete all history entries that match the filter (e.g. alias that have "prod" in them)
+  {{.CommandPath}} history rm --filter alias=*prod*
+`
+)
+
+func rmCommand() (*cobra.Command, error) {
+	cfg := config.NewConfigurationSet()
+
+	importCmd := &cobra.Command{
+		Use:     "rm",
+		Args:    cobra.ArbitraryArgs,
+		Short:   shortDescRm,
+		Long:    longDescRm,
+		Example: examplesRm,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			flags.BindFlags(cmd)
+			flags.PopulateConfigFromCommand(cmd, cfg)
+
+			if err := config.ApplyToConfigSet(cfg); err != nil {
+				return fmt.Errorf("applying app config: %w", err)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			zap.S().Debug("running `history rm` command")
+
+			params := &app.HistoryRemoveInput{
+				RemoveList: args,
+			}
+
+			if err := config.Unmarshall(cfg, params); err != nil {
+				return fmt.Errorf("unmarshalling config into to params: %w", err)
+			}
+
+			historyLoader, err := loader.NewFileLoader(params.Location)
+			if err != nil {
+				return fmt.Errorf("getting history loader with path %s: %w", params.Location, err)
+			}
+			store, err := history.NewStore(maxHistoryEntries, historyLoader)
+			if err != nil {
+				return fmt.Errorf("creating history store: %w", err)
+			}
+
+			a := app.New(app.WithHistoryStore(store))
+
+			ctx := provider.NewContext(
+				provider.WithConfig(cfg),
+			)
+
+			return a.HistoryRemove(ctx, params)
+		},
+	}
+	utils.FormatCommand(importCmd)
+
+	if err := addConfigRm(cfg); err != nil {
+		return nil, fmt.Errorf("adding export command config: %w", err)
+	}
+
+	if err := flags.CreateCommandFlags(importCmd, cfg); err != nil {
+		return nil, err
+	}
+
+	return importCmd, nil
+
+}
+
+func addConfigRm(cs config.ConfigurationSet) error {
+
+	if err := app.AddCommonConfigItems(cs); err != nil {
+		return fmt.Errorf("adding common config: %w", err)
+	}
+	if err := app.AddHistoryLocationItems(cs); err != nil {
+		return fmt.Errorf("adding history location config items: %w", err)
+	}
+
+	if err := app.AddHistoryRemoveConfig(cs); err != nil {
+		return fmt.Errorf("adding history remove config items: %w", err)
+	}
+	return nil
+}

--- a/pkg/history/store_test.go
+++ b/pkg/history/store_test.go
@@ -232,6 +232,34 @@ func Test_FileStoreRemove(t *testing.T) {
 			},
 			errorExpected: true,
 		},
+		{
+			name:            "Existing history, remove middle entry",
+			input:           createEntry("1"),
+			existingHistory: createHistoryList(3),
+			maxItems:        10,
+			expect: func(mockLoader *mock_loader.MockLoader, input *historyv1alpha.HistoryEntry, existing *historyv1alpha.HistoryEntryList) {
+				expectedList := historyv1alpha.NewHistoryEntryList()
+				entry := createEntry("0")
+				expectedList.Items = append(expectedList.Items, *entry)
+				entry2 := createEntry("2")
+				expectedList.Items = append(expectedList.Items, *entry2)
+				
+				mockLoader.
+					EXPECT().
+					Load().
+					DoAndReturn(func() (*historyv1alpha.HistoryEntryList, error) {
+						return existing, nil
+					}).Times(1)
+
+				mockLoader.
+					EXPECT().
+					Save(matchers.MatchHistoryList(expectedList)).
+					DoAndReturn(func(historyList *historyv1alpha.HistoryEntryList) error {
+						return nil
+					}).Times(1)
+			},
+			errorExpected: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows users to delete history entries

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #283 