### PR TITLE
feat: change version check error to warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/beevik/etree v1.1.0
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/brianvoe/gofakeit/v5 v5.10.1
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-playground/validator/v10 v10.3.0
 	github.com/golang/mock v1.3.1
 	github.com/golangci/golangci-lint v1.31.0 // indirect

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -150,7 +150,7 @@ func RootCmd() (*cobra.Command, error) {
 			}
 			if !params.DisableVersionCheck {
 				if err := reportNewerVersion(); err != nil {
-					return fmt.Errorf("reporting newer version: %w", err)
+					zap.S().Warnf("problem reporting newer version: %s", err.Error())
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Change behavior of new version check to display a warning instead of erroring out (if there is a problem checking it)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #294 