### PR TITLE
fix: root peristent commands not being used

### DIFF
--- a/internal/commands/alias/add.go
+++ b/internal/commands/alias/add.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -64,8 +65,11 @@ func addCommand() (*cobra.Command, error) { //nolint: dupl
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/alias/ls.go
+++ b/internal/commands/alias/ls.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -67,8 +68,11 @@ func lsCommand() (*cobra.Command, error) { //nolint: dupl
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/alias/remove.go
+++ b/internal/commands/alias/remove.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -68,8 +69,11 @@ func removeCommand() (*cobra.Command, error) { //nolint: dupl
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -72,8 +73,11 @@ func Command() (*cobra.Command, error) {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/history/export.go
+++ b/internal/commands/history/export.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -59,8 +60,11 @@ func exportCommand() (*cobra.Command, error) {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/history/import.go
+++ b/internal/commands/history/import.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -71,8 +72,11 @@ func importCommand() (*cobra.Command, error) {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/history/rm.go
+++ b/internal/commands/history/rm.go
@@ -19,6 +19,7 @@ package history
 import (
 	"fmt"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -64,8 +65,11 @@ func rmCommand() (*cobra.Command, error) {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/logout/logout.go
+++ b/internal/commands/logout/logout.go
@@ -19,6 +19,7 @@ package logout
 import (
 	"fmt"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -48,8 +49,11 @@ func Command() (*cobra.Command, error) {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/ls/ls.go
+++ b/internal/commands/ls/ls.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/flags"
@@ -79,8 +80,11 @@ func Command() (*cobra.Command, error) {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, cfg)
-
-			if err := config.ApplyToConfigSet(cfg); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, cfg)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSet(commonCfg.ConfigFile, cfg); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
+	"github.com/fidelity/kconnect/internal/helpers"
 	"github.com/fidelity/kconnect/pkg/app"
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/defaults"
@@ -153,7 +154,11 @@ func createProviderCmd(registration *registry.DiscoveryPluginRegistration) (*cob
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags.BindFlags(cmd)
 			flags.PopulateConfigFromCommand(cmd, params.ConfigSet)
-			if err := config.ApplyToConfigSetWithProvider(params.ConfigSet, registration.Name); err != nil {
+			commonCfg, err := helpers.GetCommonConfig(cmd, params.ConfigSet)
+			if err != nil {
+				return fmt.Errorf("gettng common config: %w", err)
+			}
+			if err := config.ApplyToConfigSetWithProvider(commonCfg.ConfigFile, params.ConfigSet, registration.Name); err != nil {
 				return fmt.Errorf("applying app config: %w", err)
 			}
 

--- a/internal/helpers/common.go
+++ b/internal/helpers/common.go
@@ -1,0 +1,30 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/fidelity/kconnect/pkg/app"
+	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/defaults"
+	"github.com/fidelity/kconnect/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+func GetCommonConfig(cmd *cobra.Command, cfg config.ConfigurationSet) (*app.CommonConfig, error) {
+	flags.PopulateConfigFromCommand(cmd, cfg)
+
+	configPath := cfg.ValueString(app.ConfigPathConfigItem)
+	if configPath == "" {
+		configPath = defaults.ConfigPath()
+	}
+
+	if err := config.ApplyToConfigSetWithProvider(configPath, cfg, ""); err != nil {
+		return nil, fmt.Errorf("applying app config: %w", err)
+	}
+	params := &app.CommonConfig{}
+	if err := config.Unmarshall(cfg, params); err != nil {
+		return nil, fmt.Errorf("unmarshalling config into to params: %w", err)
+	}
+
+	return params, nil
+}

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -27,6 +27,8 @@ import (
 const (
 	NoInputConfigItem        = "no-input"
 	NonInteractiveConfigItem = "non-interactive"
+	NoVersionCheckConfigItem = "no-version-check"
+	ConfigPathConfigItem     = "config"
 )
 
 type HistoryLocationConfig struct {
@@ -93,7 +95,7 @@ type CommonConfig struct {
 }
 
 func AddCommonConfigItems(cs config.ConfigurationSet) error {
-	if _, err := cs.String("config", "", "Configuration file for application wide defaults. (default \"$HOME/.kconnect/config.yaml\")"); err != nil {
+	if _, err := cs.String(ConfigPathConfigItem, "", "Configuration file for application wide defaults. (default \"$HOME/.kconnect/config.yaml\")"); err != nil {
 		return fmt.Errorf("adding config item: %w", err)
 	}
 	if _, err := cs.Int("verbosity", 0, "Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace."); err != nil {
@@ -105,15 +107,15 @@ func AddCommonConfigItems(cs config.ConfigurationSet) error {
 	if _, err := cs.Bool(NoInputConfigItem, false, "Explicitly disable interactivity when running in a terminal"); err != nil {
 		return fmt.Errorf("adding no-input config: %w", err)
 	}
-	if _, err := cs.Bool("no-version-check", false, "If set to true kconnect will not check for a newer version"); err != nil {
+	if _, err := cs.Bool(NoVersionCheckConfigItem, false, "If set to true kconnect will not check for a newer version"); err != nil {
 		return fmt.Errorf("adding non-version-check config: %w", err)
 	}
 	cs.SetShort("verbosity", "v")                                       //nolint
-	cs.SetHistoryIgnore("config")                                       //nolint
+	cs.SetHistoryIgnore(ConfigPathConfigItem)                           //nolint
 	cs.SetHistoryIgnore("verbosity")                                    //nolint
 	cs.SetHistoryIgnore(NonInteractiveConfigItem)                       //nolint
 	cs.SetHistoryIgnore(NoInputConfigItem)                              //nolint
-	cs.SetHistoryIgnore("no-version-check")                             //nolint
+	cs.SetHistoryIgnore(NoVersionCheckConfigItem)                       //nolint
 	cs.SetDeprecated(NonInteractiveConfigItem, "please use --no-input") //nolint
 
 	return nil

--- a/pkg/app/to.go
+++ b/pkg/app/to.go
@@ -57,7 +57,7 @@ func (a *App) ConnectTo(ctx context.Context, params *ConnectToInput) error {
 	}
 	historyID := entry.ObjectMeta.Name
 
-	cs, err := a.buildConnectToConfig(entry.Spec.Provider, entry.Spec.Identity, entry)
+	cs, err := a.buildConnectToConfig(params.ConfigFile, entry.Spec.Provider, entry.Spec.Identity, entry)
 	if err != nil {
 		return fmt.Errorf("building connectTo config set: %w", err)
 	}
@@ -187,7 +187,7 @@ func (a *App) generateOptions(params *ConnectToInput, entries *historyv1alpha.Hi
 	return options, nil
 }
 
-func (a *App) buildConnectToConfig(idProvider string, discoveryProvider string, historyEntry *historyv1alpha.HistoryEntry) (config.ConfigurationSet, error) {
+func (a *App) buildConnectToConfig(configFile string, idProvider string, discoveryProvider string, historyEntry *historyv1alpha.HistoryEntry) (config.ConfigurationSet, error) {
 	cs := config.NewConfigurationSet()
 
 	idProviderReg, err := registry.GetIdentityProviderRegistration(idProvider)
@@ -256,7 +256,7 @@ func (a *App) buildConnectToConfig(idProvider string, discoveryProvider string, 
 		}
 	}
 
-	if err := config.ApplyToConfigSetWithProvider(cs, discoveryProvider); err != nil {
+	if err := config.ApplyToConfigSetWithProvider(configFile, cs, discoveryProvider); err != nil {
 		return nil, fmt.Errorf("applying app config: %w", err)
 	}
 

--- a/pkg/config/apply.go
+++ b/pkg/config/apply.go
@@ -22,18 +22,18 @@ import (
 )
 
 // ApplyToConfigSet will apply the saved app configuration to the supplied config set.
-func ApplyToConfigSet(cs ConfigurationSet) error {
-	return applyConfiguration(cs, "")
+func ApplyToConfigSet(configPath string, cs ConfigurationSet) error {
+	return applyConfiguration(configPath, cs, "")
 }
 
 // ApplyToConfigSetWithProvider will apply the saved app configuration to the supplied config set and
 // will take into consideration provider specific overrides
-func ApplyToConfigSetWithProvider(cs ConfigurationSet, provider string) error {
-	return applyConfiguration(cs, provider)
+func ApplyToConfigSetWithProvider(configPath string, cs ConfigurationSet, provider string) error {
+	return applyConfiguration(configPath, cs, provider)
 }
 
-func applyConfiguration(cs ConfigurationSet, provider string) error {
-	appConfig, err := NewAppConfiguration()
+func applyConfiguration(configPath string, cs ConfigurationSet, provider string) error {
+	appConfig, err := NewAppConfigurationWithPath(configPath)
 	if err != nil {
 		return fmt.Errorf("creating app config store: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
There was issues with the peristsnet commands being.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #