### PR TITLE
fix: panic as httpclient not peristed to provider

### DIFF
--- a/pkg/plugins/identity/rancher/activedirectory/activedirectory.go
+++ b/pkg/plugins/identity/rancher/activedirectory/activedirectory.go
@@ -68,6 +68,7 @@ func New(input *provider.PluginCreationInput) (identity.Provider, error) {
 	return &radIdentityProvider{
 		logger:      input.Logger,
 		interactive: input.IsInteractice,
+		httpClient:  input.HTTPClient,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After the recent factor there was an issue with the Rancher Active Directort plugin

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #