### PR TITLE
docs: fix wstrust link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Contributions are very welcome. Please read the [contributing guide](CONTRIBUTIN
 
 ## Acknowledgements
 
-For the SAML identity provider we rely heavily on the [saml2aws](https://github.com/Versent/saml2aws) project by Versent. For the Azure AD provider we have taken inspiration from the [Microsoft Authentication Library for Go](https://github.com/AzureAD/microsoft-authentication-library-for-go) and have directly used their wstrust package (see [pkg/azure/wstrust](pkg/azure/wstruct)).
+For the SAML identity provider we rely heavily on the [saml2aws](https://github.com/Versent/saml2aws) project by Versent. For the Azure AD provider we have taken inspiration from the [Microsoft Authentication Library for Go](https://github.com/AzureAD/microsoft-authentication-library-for-go) and have directly used their wstrust package (see [pkg/azure/wstrust](pkg/azure/wstrust)).
 
 Thanks to both these projects for making the implementation easier.


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects a typo in the link to the wstrust package at the bottom of the readme page.

**Which issue(s) this PR fixes**:
n/a

<hr />

See @aido123, ask for contributions and you shall receive them :laughing: I may actually be open to trying to tackle something more substantive down the road, but happened to stumble across this broken link the other day while reading and figured I'd start here.