### PR TITLE
feat: aws region regex filter

### DIFF
--- a/docs/book/src/commands/use_eks.md
+++ b/docs/book/src/commands/use_eks.md
@@ -64,7 +64,7 @@ kconnect use eks [flags]
       --partition string          AWS partition to use (default "aws")
       --password string           The password to use for authentication
       --region string             AWS region to connect to
-      --region-filter string      A filter to apply to the AWS regions list, e.g. 'us-' will only show US regions
+      --region-filter string      A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions
       --role-arn string           ARN of the AWS role to be assumed
       --role-filter string        A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name
       --set-current               Sets the current context in the kubeconfig to the selected cluster (default true)

--- a/pkg/aws/resolve.go
+++ b/pkg/aws/resolve.go
@@ -63,11 +63,6 @@ func ResolveRegion(cfg config.ConfigurationSet) error {
 	}
 
 	options := []string{}
-	// for _, region := range partition.Regions() {
-	// 	if regionFilter == "" || strings.Contains(region.ID(), regionFilter) {
-	// 		options = append(options, region.ID())
-	// 	}
-	// }
 	for _, region := range partition.Regions() {
 		options = append(options, region.ID())
 	}

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -127,9 +127,9 @@ func (p *eksClusterProvider) CheckPreReqs() error {
 func ConfigurationItems(scopeTo string) (config.ConfigurationSet, error) {
 	cs := aws.SharedConfig()
 
-	cs.String("region-filter", "", "A filter to apply to the AWS regions list, e.g. 'us-' will only show US regions")                 //nolint: errcheck
-	cs.String("role-arn", "", "ARN of the AWS role to be assumed")                                                                    //nolint: errcheck
-	cs.String("role-filter", "", "A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name") //nolint: errcheck
+	cs.String("region-filter", "", "A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions") //nolint: errcheck
+	cs.String("role-arn", "", "ARN of the AWS role to be assumed")                                                                       //nolint: errcheck
+	cs.String("role-filter", "", "A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name")    //nolint: errcheck
 
 	return cs, nil
 }

--- a/pkg/utils/filter.go
+++ b/pkg/utils/filter.go
@@ -29,3 +29,19 @@ func SurveyFilter(filter string, value string, index int) bool {
 	}
 	return true
 }
+
+// RegexFilter to filter a slice or strings based on a regex filter passed to it. Returns an error if regex is invalid
+func RegexFilter(options []string, regexString string) ([]string, error) {
+
+	var filteredOptions []string
+	reg, err := regexp.Compile(regexString)
+	if err != nil {
+		return filteredOptions, err
+	}
+	for _, opt := range options {
+		if reg.MatchString(opt) {
+			filteredOptions = append(filteredOptions, opt)
+		}
+	}
+	return filteredOptions, nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,8 +1,11 @@
 package utils
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-func Test_Filter(t *testing.T) {
+func Test_SurveyFilter(t *testing.T) {
 	testCases := []struct {
 		name        string
 		inputValue  string
@@ -69,3 +72,69 @@ func Test_Filter(t *testing.T) {
 	}
 
 }
+
+
+
+func Test_RegexFilter(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		inputRegex              string
+		inputOptions            []string
+		expectedFilteredOptions []string
+		expectErr               bool
+	}{
+		{
+			name:                    "empty filter",
+			inputRegex:              "",
+			inputOptions:            []string{"test1", "test2"},
+			expectedFilteredOptions: []string{"test1", "test2"},
+			expectErr:               false,
+		},
+		{
+			name:                    "simple filter",
+			inputRegex:              "test",
+			inputOptions:            []string{"test1", "test2", "blah"},
+			expectedFilteredOptions: []string{"test1", "test2"},
+			expectErr:               false,
+		},
+		{
+			name:                    "exact match filter",
+			inputRegex:              "^test2$",
+			inputOptions:            []string{"1test2", "test21", "test2"},
+			expectedFilteredOptions: []string{"test2"},
+			expectErr:               false,
+		},
+		{
+			name:                    "multiple filter",
+			inputRegex:              "^us-east|^eu-west-2$",
+			inputOptions:            []string{"us-east-1", "us-east-2", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-1", "ap-northeast-3", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ca-central-1", "cn-north-1", "cn-northwest-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-south-1", "eu-west-3", "eu-north-1", "me-south-1", "sa-east-1"},
+			expectedFilteredOptions: []string{"us-east-1", "us-east-2", "eu-west-2"},
+			expectErr:               false,
+		},
+		{
+			name:                    "bad filter",
+			inputRegex:              "*",
+			inputOptions:            []string{"test1", "test2"},
+			expectedFilteredOptions: []string{},
+			expectErr:               true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualFilteredOptions, actualErr := RegexFilter(tc.inputOptions, tc.inputRegex)
+			if actualErr != nil {
+				if !tc.expectErr {
+					t.Fatalf("expected %t but got %t", tc.expectErr, actualErr)
+				}	
+			} else {
+				if !reflect.DeepEqual(tc.expectedFilteredOptions, actualFilteredOptions) {
+					t.Fatalf("expected %v but got %v", tc.expectedFilteredOptions, actualFilteredOptions)
+				}
+			}
+		})
+	}
+
+}
+
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes eks region filter to use regex, allowing for a lot more flexibility in setting this in the kconnect config file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #368 