### PR TITLE
feat: add user instruction to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY  kconnect /
 
+RUN adduser -D kconnect
+USER kconnect
 ENTRYPOINT ["/kconnect"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,4 +3,6 @@ FROM alpine:3.14
 RUN apk --no-cache add ca-certificates
 COPY  kconnect /
 
+RUN adduser -D kconnect
+USER kconnect
 ENTRYPOINT ["/kconnect"]

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -37,4 +37,6 @@ COPY --from=builder bin/linux_amd64/kubelogin .
 COPY --from=builder linux-amd64/helm .
 COPY kconnect .
 
+RUN adduser -D kconnect
+USER kconnect
 ENTRYPOINT ["/app/kconnect"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will add a `USER` instruction to all of the `Dockerfiles`, such that the Docker images will not run as the `root` user.

This is considered a best practice, has been request, and is required by some users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #380 

**Testing:**
I created a test image locally, and the changes work as expected:
```
% docker run --rm -it --entrypoint sh kconnect-deps:test
/app $ whoami
kconnect
```
Also, `kconnect` still runs as expected:
```
% docker run --rm -it --entrypoint sh kconnect-deps:test
/app $ kconnect config -f http://<url>
...
info	successfully imported configuration
/app $ kconnect use eks
...
info	kubeconfig updated	{"path": "/home/kconnect/.kube/config"}
/app $ kubectl get po
NAME        READY   STATUS    RESTARTS   AGE
<test-pod>  1/1     Running   0          3d12h
```