### PR TITLE
fix(actions): switch action, and update installation doc

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,11 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@v2.2.5
-      with:
-        success-state: Title follows the specification.
-        failure-state: Title does not follow the specification.
-        context-name: conventional-pr-title
-        preset: conventional-changelog-angular@latest
+      uses: amannn/action-semantic-pull-request@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -2,7 +2,7 @@ name: titlecheck
 
 # Run on PR
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
@@ -13,9 +13,6 @@ jobs:
   titlecheck:
     name: PR title follows coventional commit
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
     - name: Check conventinal title
       uses: aslafy-z/conventional-pr-title-action@v2.2.5

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -13,9 +13,12 @@ jobs:
   titlecheck:
     name: PR title follows coventional commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@master
+      uses: aslafy-z/conventional-pr-title-action@v2.2.5
       with:
         success-state: Title follows the specification.
         failure-state: Title does not follow the specification.

--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -7,7 +7,7 @@
 
 <em>NOTE:</em> `kconnect` requires [kubectl >= 1.17.0](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 
-<em>NOTE:</em> `kconnect` requires [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) to authenticate to the AWS EKS cluster provider.
+<em>NOTE:</em> `kconnect` requires [aws-iam-authenticator >= 0.5.5](https://github.com/kubernetes-sigs/aws-iam-authenticator) to authenticate to the AWS EKS cluster provider.
 
 <em>NOTE:</em> `kconnect` requires [kubelogin](https://github.com/Azure/kubelogin) to authenticate to Azure AKS clusters.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to hopefully fix this issue with the `titlecheck` Github Action, and update the `installation` doc to include the new minimum required `aws-iam-authenticator` version now that we updated the `apiVersion` within `kconnect`.

This is the error we are seeing whenever a PR gets opened by a forked repository:
`Error: Resource not accessible by integration`
[Example failed job message](https://github.com/fidelity/kconnect/runs/5540519833?check_suite_focus=true)
If the PR comes from within the `kconnect` repository, we will not see this error.

There is a closed issue within the Github Action that references this error message, but the Github issue redirects to two other links:
- https://github.com/aslafy-z/conventional-pr-title-action/issues/119 

There is also this new Github Action event that we can try called, `pull_request_target`, but the Github Action indicates that we must use `pull_request`:
- [conventional-pr-title-action/index.js at master · aslafy-z/conventional-pr-title-action](https://github.com/aslafy-z/conventional-pr-title-action/blob/master/src/index.js#L20)

Therefore, we are switching to this new Github Action that supports `pull_request_target`:
- https://github.com/amannn/action-semantic-pull-request

It also explains the difference between the two Github Action event triggers, and that with this new event trigger it will not run until after it is merged into the `main` branch:
- https://github.com/amannn/action-semantic-pull-request#event-triggers

For more information on the new event:
- [Events that trigger workflows - GitHub Docs (pull_request_target)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
- [GitHub Actions improvements for fork and pull request workflows | The GitHub Blog](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)
- [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests | GitHub Security Lab](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)