### PR TITLE
feat(actions): release-docs action name was the same as creating a release action

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,24 +1,24 @@
-name: goreleaser
+name: release-docs
 
 on:
-    push:
-        tags:
-            - "*"
+  push:
+    tags:
+      - "*"
 
 jobs:
-    goreleaser:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
-                  submodules: true
-            - name: Build Docs
-              run: |
-                make docs-build
-            - name: Deploy
-              uses: peaceiris/actions-gh-pages@v3
-              with:
-                github_token: ${{ secrets.GITHUB_TOKEN }}
-                publish_dir: ./docs/book/book
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Build Docs
+        run: |
+          make docs-build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book/book


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will update the name of the Github Action that handles the releasing of the documentation. Currently, the Github Action name matches the Github Action that handles creating a release. Therefore, it is confusing to figure out which one is the correct Github Action. By changing the name of the Github Action, this should help avoid confusion and debugging.
<img width="472" alt="Screen Shot 2022-03-21 at 4 40 00 PM" src="https://user-images.githubusercontent.com/4017416/159360006-6336428b-9e48-47ae-8cc4-237b28df1a5b.png">

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #