### PR TITLE
feat(actions): revert to old titlechecker in order to hopefully fix the orphaned context check

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -11,10 +11,15 @@ on:
 
 jobs:
   titlecheck:
-    name: PR title follows coventional commit
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: amannn/action-semantic-pull-request@v4
+      uses: aslafy-z/conventional-pr-title-action@v2.2.5
+      with:
+        success-state: Title follows the specification.
+        failure-state: Title does not follow the specification.
+        context-name: conventional-pr-title
+        preset: conventional-changelog-angular@latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will hopefully fix this issue I have been noticing where there is a Github Action check that never completes.
<img width="841" alt="Screen Shot 2022-03-24 at 12 50 59 AM" src="https://user-images.githubusercontent.com/4017416/159844661-3e78baba-a5e3-4ba6-9726-a437c811c809.png">

I noticed with the newer PR title checker they only set the `context` if the Github Action fails, where the original PR title checker will always set the `context`:
- https://github.com/aslafy-z/conventional-pr-title-action/blob/da8f29a36764af935378bfe7e30ae4dcf692547a/src/index.js#L53

I also could not find anything online about removing, or cleaning up, this possible orphaned check. Therefore, I believe reverting back to the original PR title checker with the new `pull_request_target` Github Action event trigger will be best.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #