### PR TITLE
feat(actions): revert to new pr title checker since no checks are running now

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@v2.2.5
+      uses: aslafy-z/conventional-pr-title-action@master
       with:
         success-state: Title follows the specification.
         failure-state: Title does not follow the specification.

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,11 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@master
-      with:
-        success-state: Title follows the specification.
-        failure-state: Title does not follow the specification.
-        context-name: conventional-pr-title
-        preset: conventional-changelog-angular@latest
+      uses: amannn/action-semantic-pull-request@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing PR title checker action to see if it works now. None of the checks appear to be running, so going back to the new PR title checker.
<img width="843" alt="Screen Shot 2022-03-24 at 11 42 40 AM" src="https://user-images.githubusercontent.com/4017416/159954889-f421e3d7-b3e5-4603-840c-ac09cae130d5.png">

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #