### PR TITLE
feat(actions): revert to original pr title action now that Github Actions are healthy again

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: amannn/action-semantic-pull-request@v4
+      uses: amannn/action-semantic-pull-request@v4.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: amannn/action-semantic-pull-request@v4.2.0
+      uses: aslafy-z/conventional-pr-title-action@master
+      with:
+        success-state: Title follows the specification.
+        failure-state: Title does not follow the specification.
+        context-name: conventional-pr-title
+        preset: conventional-changelog-angular@latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing PR action again.

Turns out Github Actions is having issues 🤦 
<img width="983" alt="Screen Shot 2022-03-24 at 11 46 32 AM" src="https://user-images.githubusercontent.com/4017416/159955829-57651fea-72c7-4f86-b27d-e18fea6eda9f.png">

> **Edit:** Now that Github Actions are healthy, I am going to try the original PR title checker in order to fix that orphan context again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #