### PR TITLE
feat(actions): revert pr title checker action job name, and pin version

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   titlecheck:
-    name: Validate PR title
+    name: PR title follows coventional commit
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@master
+      uses: aslafy-z/conventional-pr-title-action@v2.2.5
       with:
         success-state: Title follows the specification.
         failure-state: Title does not follow the specification.


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing PR titlechecker Github Action.

The `conventional-pr-title` context completes successfully, but now `PR title follows coventional commit` hangs around so reverting that change as well.
<img width="842" alt="Screen Shot 2022-03-24 at 4 17 34 PM" src="https://user-images.githubusercontent.com/4017416/160002639-c1439a06-b55e-4f35-bdfd-92cb0ac077df.png">

Starting to think in order to remove or change this we would need to create an entirely new workflow YAML, instead of reusing the `titlechecker.yaml` file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #