### PR TITLE
feat: allow setting of aws shared credentials file location

### DIFF
--- a/docs/book/src/commands/use_eks.md
+++ b/docs/book/src/commands/use_eks.md
@@ -52,23 +52,24 @@ kconnect use eks [flags]
 ### Options
 
 ```bash
-  -a, --alias string              Friendly name to give to give the connection
-  -c, --cluster-id string         Id of the cluster to use.
-  -h, --help                      help for eks
-      --history-location string   Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
-      --idp-protocol string       The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.
-  -k, --kubeconfig string         Location of the kubeconfig to use. (default "$HOME/.kube/config")
-      --max-history int           Sets the maximum number of history items to keep (default 100)
-  -n, --namespace string          Sets namespace for context in kubeconfig
-      --no-history                If set to true then no history entry will be written
-      --partition string          AWS partition to use (default "aws")
-      --password string           The password to use for authentication
-      --region string             AWS region to connect to
-      --region-filter string      A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions
-      --role-arn string           ARN of the AWS role to be assumed
-      --role-filter string        A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name
-      --set-current               Sets the current context in the kubeconfig to the selected cluster (default true)
-      --username string           The username used for authentication
+  -a, --alias string                         Friendly name to give to give the connection
+      --aws-shared-credentials-file string   Location to store AWS credentials file
+  -c, --cluster-id string                    Id of the cluster to use.
+  -h, --help                                 help for eks
+      --history-location string              Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --idp-protocol string                  The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.
+  -k, --kubeconfig string                    Location of the kubeconfig to use. (default "$HOME/.kube/config")
+      --max-history int                      Sets the maximum number of history items to keep (default 100)
+  -n, --namespace string                     Sets namespace for context in kubeconfig
+      --no-history                           If set to true then no history entry will be written
+      --partition string                     AWS partition to use (default "aws")
+      --password string                      The password to use for authentication
+      --region string                        AWS region to connect to
+      --region-filter string                 A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions
+      --role-arn string                      ARN of the AWS role to be assumed
+      --role-filter string                   A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name
+      --set-current                          Sets the current context in the kubeconfig to the selected cluster (default true)
+      --username string                      The username used for authentication
 ```
 
 ### Options inherited from parent commands

--- a/pkg/aws/clients.go
+++ b/pkg/aws/clients.go
@@ -32,13 +32,13 @@ import (
 	"github.com/fidelity/kconnect/internal/version"
 )
 
-func NewSession(region, profile, accessKey, secretKey, sessionToken string) (*session.Session, error) {
+func NewSession(region, profile, accessKey, secretKey, sessionToken, awsSharedCredentialsFile string) (*session.Session, error) {
 	cfg := aws.Config{
 		Region: aws.String(region),
 	}
 
 	if profile != "" {
-		cfg.Credentials = credentials.NewSharedCredentials("", profile)
+		cfg.Credentials = credentials.NewSharedCredentials(awsSharedCredentialsFile, profile)
 	} else if accessKey != "" && secretKey != "" {
 		cfg.Credentials = credentials.NewStaticCredentials(accessKey, secretKey, sessionToken)
 	}

--- a/pkg/aws/identity.go
+++ b/pkg/aws/identity.go
@@ -22,16 +22,16 @@ import (
 
 // Identity represents an AWS identity
 type Identity struct {
-	ProfileName      string
-	AWSAccessKey     string
-	AWSSecretKey     string
-	AWSSessionToken  string
-	AWSSecurityToken string
-	PrincipalARN     string
-	Expires          time.Time
-	Region           string
-
-	IDProviderName string
+	ProfileName              string
+	AWSAccessKey             string
+	AWSSecretKey             string
+	AWSSessionToken          string
+	AWSSecurityToken         string
+	PrincipalARN             string
+	Expires                  time.Time
+	Region                   string
+	AWSSharedCredentialsFile string
+	IDProviderName           string
 }
 
 func (i *Identity) Type() string {

--- a/pkg/aws/map.go
+++ b/pkg/aws/map.go
@@ -18,16 +18,17 @@ package aws
 
 import "github.com/versent/saml2aws/pkg/awsconfig"
 
-func MapCredsToIdentity(creds *awsconfig.AWSCredentials, profileName string) *Identity {
+func MapCredsToIdentity(creds *awsconfig.AWSCredentials, profileName, awsSharedCredentialsFile string) *Identity {
 	return &Identity{
-		AWSAccessKey:     creds.AWSAccessKey,
-		AWSSecretKey:     creds.AWSSecretKey,
-		AWSSecurityToken: creds.AWSSecurityToken,
-		AWSSessionToken:  creds.AWSSessionToken,
-		Expires:          creds.Expires,
-		PrincipalARN:     creds.PrincipalARN,
-		ProfileName:      profileName,
-		Region:           creds.Region,
+		AWSAccessKey:             creds.AWSAccessKey,
+		AWSSecretKey:             creds.AWSSecretKey,
+		AWSSecurityToken:         creds.AWSSecurityToken,
+		AWSSessionToken:          creds.AWSSessionToken,
+		AWSSharedCredentialsFile: awsSharedCredentialsFile,
+		Expires:                  creds.Expires,
+		PrincipalARN:             creds.PrincipalARN,
+		ProfileName:              profileName,
+		Region:                   creds.Region,
 	}
 }
 

--- a/pkg/aws/store.go
+++ b/pkg/aws/store.go
@@ -25,9 +25,14 @@ import (
 )
 
 // NewIdentityStore will create a new AWS identity store
-func NewIdentityStore(profile, idProviderName string) (identity.Store, error) {
+func NewIdentityStore(profile, idProviderName, awsCredsFile string) (identity.Store, error) {
+
+	configProvider := awsconfig.NewSharedCredentials(profile)
+	if awsCredsFile != "" {
+		configProvider.Filename = awsCredsFile
+	}
 	return &awsIdentityStore{
-		configProvider: awsconfig.NewSharedCredentials(profile),
+		configProvider: configProvider,
 		idProviderName: idProviderName,
 	}, nil
 }
@@ -56,7 +61,7 @@ func (s *awsIdentityStore) Load() (identity.Identity, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading credentials: %w", err)
 	}
-	awsID := MapCredsToIdentity(creds, s.configProvider.Profile)
+	awsID := MapCredsToIdentity(creds, s.configProvider.Profile, s.configProvider.Filename)
 
 	return awsID, nil
 }

--- a/pkg/plugins/discovery/aws/config.go
+++ b/pkg/plugins/discovery/aws/config.go
@@ -67,6 +67,13 @@ func (p *eksClusterProvider) GetConfig(ctx context.Context, input *discovery.Get
 		},
 	}
 
+	if p.identity.AWSSharedCredentialsFile != "" {
+		execConfig.Env = append(execConfig.Env, api.ExecEnvVar{
+			Name:  "AWS_SHARED_CREDENTIALS_FILE",
+			Value: p.identity.AWSSharedCredentialsFile,
+		})
+	}
+
 	cfg.AuthInfos = map[string]*api.AuthInfo{
 		userName: {
 			Exec: execConfig,

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"go.uber.org/zap"
@@ -105,7 +106,7 @@ func (p *eksClusterProvider) setup(cs config.ConfigurationSet, userID identity.I
 	p.identity = awsID
 
 	p.logger.Debugw("creating AWS session", "region", *p.config.Region)
-	sess, err := aws.NewSession(p.identity.Region, p.identity.ProfileName, p.identity.AWSAccessKey, p.identity.AWSSecretKey, p.identity.AWSSessionToken)
+	sess, err := aws.NewSession(p.identity.Region, p.identity.ProfileName, p.identity.AWSAccessKey, p.identity.AWSSecretKey, p.identity.AWSSessionToken, p.identity.AWSSharedCredentialsFile)
 	if err != nil {
 		return fmt.Errorf("creating aws session: %w", err)
 	}
@@ -127,6 +128,7 @@ func (p *eksClusterProvider) CheckPreReqs() error {
 func ConfigurationItems(scopeTo string) (config.ConfigurationSet, error) {
 	cs := aws.SharedConfig()
 
+	cs.String("aws-shared-credentials-file", os.Getenv("AWS_SHARED_CREDENTIALS_FILE"), "Location to store AWS credentials file")
 	cs.String("region-filter", "", "A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions") //nolint: errcheck
 	cs.String("role-arn", "", "ARN of the AWS role to be assumed")                                                                       //nolint: errcheck
 	cs.String("role-filter", "", "A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name")    //nolint: errcheck

--- a/pkg/plugins/identity/aws/iam/provider.go
+++ b/pkg/plugins/identity/aws/iam/provider.go
@@ -64,12 +64,13 @@ type iamIdentityProvider struct {
 }
 
 type providerConfig struct {
-	Profile      string `json:"profile"`
-	AccessKey    string `json:"access-key"`
-	SecretKey    string `json:"secret-key"`
-	SessionToken string `json:"session-token"`
-	Region       string `json:"region"`
-	Partition    string `json:"partition"`
+	Profile                  string `json:"profile"`
+	AccessKey                string `json:"access-key"`
+	SecretKey                string `json:"secret-key"`
+	SessionToken             string `json:"session-token"`
+	Region                   string `json:"region"`
+	Partition                string `json:"partition"`
+	AWSSharedCredentialsFile string `json:"aws-shared-credentials-file"`
 }
 
 func (p *iamIdentityProvider) Name() string {
@@ -89,7 +90,7 @@ func (p *iamIdentityProvider) Authenticate(ctx context.Context, input *identity.
 		return nil, err
 	}
 
-	sess, err := kaws.NewSession(cfg.Region, cfg.Profile, cfg.AccessKey, cfg.SecretKey, cfg.SessionToken)
+	sess, err := kaws.NewSession(cfg.Region, cfg.Profile, cfg.AccessKey, cfg.SecretKey, cfg.SessionToken, cfg.AWSSharedCredentialsFile)
 	if err != nil {
 		return nil, fmt.Errorf("creating aws session: %w", err)
 	}

--- a/pkg/plugins/identity/saml/saml.go
+++ b/pkg/plugins/identity/saml/saml.go
@@ -222,7 +222,9 @@ func (p *samlIdentityProvider) createIdentityStore(cfg config.ConfigurationSet) 
 		}
 		profileCfg := cfg.Get("aws-profile")
 		profile := profileCfg.Value.(string)
-		store, err = kaws.NewIdentityStore(profile, ProviderName)
+		awsCredsFileCfg := cfg.Get("aws-shared-credentials-file")
+		awsCredsFile := awsCredsFileCfg.Value.(string)
+		store, err = kaws.NewIdentityStore(profile, ProviderName, awsCredsFile)
 	default:
 		return nil, ErrUnsuportedProvider
 	}

--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -140,7 +140,13 @@ func (p *ServiceProvider) ProcessAssertions(account *cfg.IDPAccount, samlAsserti
 		return nil, fmt.Errorf("setting profile name: %w", err)
 	}
 
-	awsIdentity := kaws.MapCredsToIdentity(awsCreds, profileName)
+	awsSharedCredentialsFile := ""
+	if cfg.ExistsWithValue("aws-shared-credentials-file") {
+		item := cfg.Get("aws-shared-credentials-file")
+		awsSharedCredentialsFile = item.Value.(string)
+	}
+
+	awsIdentity := kaws.MapCredsToIdentity(awsCreds, profileName, awsSharedCredentialsFile)
 	return awsIdentity, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Users can now specify where to store AWS shared credentials file, instead of the default location at $HOME/.aws/credentials

The aws-iam-authenticator section in kubeconfig will also be updated to reflect this new location

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #388 