### PR TITLE
fix: issue 352 kconnect doesn't respect -k --kubeconfig

### DIFF
--- a/pkg/app/to.go
+++ b/pkg/app/to.go
@@ -83,6 +83,7 @@ func (a *App) ConnectTo(ctx context.Context, params *ConnectToInput) error {
 	useParams.SetCurrent = params.SetCurrent
 	useParams.IgnoreAlias = true
 	useParams.Alias = entry.Spec.Alias
+	useParams.KubernetesConfig = params.KubernetesConfig
 
 	return a.Use(ctx, useParams)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where passing in the `-k` flag to `kconnect to` with a custom kubeconfig path honors it instead of writing it to the default kubeconfig path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #352 