### PR TITLE
Feature/420 support aks cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.1
-	github.com/Azure/azure-sdk-for-go v48.2.2+incompatible
+	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.15
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.5
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eim
 github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
 github.com/Azure/azure-sdk-for-go v48.2.2+incompatible h1:dvb8umwaTvnGFBq6T9qTs7hMo/Cy3XdYfrC9NZ61fj8=
 github.com/Azure/azure-sdk-for-go v48.2.2+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
+github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=

--- a/pkg/azure/client/client.go
+++ b/pkg/azure/client/client.go
@@ -19,7 +19,7 @@ package client
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-09-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-11-01/subscriptions"
 	"github.com/Azure/go-autorest/autorest"
 

--- a/pkg/plugins/discovery/azure/config.go
+++ b/pkg/plugins/discovery/azure/config.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-09-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 
 	azclient "github.com/fidelity/kconnect/pkg/azure/client"
 	"github.com/fidelity/kconnect/pkg/azure/id"
@@ -100,6 +100,8 @@ func (p *aksClusterProvider) addKubelogin(cfg *api.Config) {
 			p.config.TenantID,
 			"--login",
 			string(p.config.LoginType),
+			"--server-fqdn-type",
+			"public",
 		},
 	}
 
@@ -150,9 +152,9 @@ func (p *aksClusterProvider) getKubeconfig(ctx context.Context, cluster *discove
 
 	var credentialList containerservice.CredentialResults
 	if p.config.Admin {
-		credentialList, err = client.ListClusterAdminCredentials(ctx, resourceID.ResourceGroupName, resourceID.ResourceName)
+		credentialList, err = client.ListClusterAdminCredentials(ctx, resourceID.ResourceGroupName, resourceID.ResourceName, p.config.ServerFqdnType)
 	} else {
-		credentialList, err = client.ListClusterUserCredentials(ctx, resourceID.ResourceGroupName, resourceID.ResourceName)
+		credentialList, err = client.ListClusterUserCredentials(ctx, resourceID.ResourceGroupName, resourceID.ResourceName, p.config.ServerFqdnType, "azure")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getting user credentials: %w", err)

--- a/pkg/plugins/discovery/azure/defaults.go
+++ b/pkg/plugins/discovery/azure/defaults.go
@@ -27,4 +27,5 @@ const (
 	ClusterNameConfigItem      = "cluster-name"
 	LoginTypeConfigItem        = "login-type"
 	AzureEnvironmentConfigItem = "azure-env"
+	ServerFqdnTypeConfigItem   = "server-fqdn-type"
 )

--- a/pkg/plugins/discovery/azure/discover.go
+++ b/pkg/plugins/discovery/azure/discover.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-09-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-03-01/containerservice"
 
 	azclient "github.com/fidelity/kconnect/pkg/azure/client"
 	"github.com/fidelity/kconnect/pkg/azure/id"

--- a/pkg/plugins/discovery/azure/provider.go
+++ b/pkg/plugins/discovery/azure/provider.go
@@ -86,6 +86,7 @@ type aksClusterProviderConfig struct {
 	ClientID         string      `json:"client-id"`
 	LoginType        LoginType   `json:"login-type"`
 	AzureEnvironment Environment `json:"azure-env"`
+	ServerFqdnType   string   	 `json:"server-fqdn-type"`
 }
 
 type aksClusterProvider struct {
@@ -152,7 +153,8 @@ func ConfigurationItems(scopeTo string) (config.ConfigurationSet, error) {
 	cs.String(ClusterNameConfigItem, "", "The name of the AKS cluster")                                                                                                                      //nolint: errcheck
 	cs.String(LoginTypeConfigItem, string(LoginTypeDeviceCode), "The login method to use when connecting to the AKS cluster as a non-admin. Possible values: devicecode,spn,ropc,msi,token") //nolint: errcheck
 	cs.String(AzureEnvironmentConfigItem, string(EnvironmentPublicCloud), "The Azure environment the clusters are in. Possible values: public,china,usgov,stack")                            //nolint: errcheck
-
+	cs.String(ServerFqdnTypeConfigItem, "public", "Connect to AKS cluster via Public/Private FQDN")
+	
 	cs.SetShort(ResourceGroupConfigItem, "r") //nolint: errcheck
 
 	return cs, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for new format field found in 1.24 AKS Clusters, enables a new flag to specify what API Server FQDN (Public or Private).
Also updates the versions of certain modules to allow for this change.
  
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #420 