### PR TITLE
feat: 424 azure auth deprecated

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -28,7 +28,7 @@ RUN curl -L \
 RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -o helm.tar.gz && \
     tar xvfz helm.tar.gz
 
-FROM alpine:3.14
+FROM mcr.microsoft.com/azure-cli:2.38.0
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /app/

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ lint: $(GOLANGCI_LINT) # Run the linter across the codebase
 	$(GOLANGCI_LINT) run -v
 
 .PHONY: ci
-ci: build test lint # Target for CI
+ci: lint test build # Target for CI
 
 
 ##@ Utility

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/99designs/keyring v0.0.0-20190110203331-82da6802f65f/go.mod h1:aKt8W/
 github.com/AlecAivazis/survey/v2 v2.0.5/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
 github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eimREzLWI=
 github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
-github.com/Azure/azure-sdk-for-go v48.2.2+incompatible h1:dvb8umwaTvnGFBq6T9qTs7hMo/Cy3XdYfrC9NZ61fj8=
-github.com/Azure/azure-sdk-for-go v48.2.2+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -75,7 +75,11 @@ specified cluster provider.
 	eksDescNote = `
 * Note: kconnect use eks requires aws-iam-authenticator.
   [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator)
-
+`
+	aksDescNote = `
+* Note: kconnect use aks requires kubelogin and azure cli.
+  [kubelogin](https://github.com/Azure/kubelogin)
+  [azure cli](https://docs.microsoft.com/en-us/cli/azure/)
 `
 	usageExample = `
   # Connect to EKS and choose an available EKS cluster.
@@ -95,7 +99,7 @@ specified cluster provider.
 
 // Command creates the use command
 func Command() (*cobra.Command, error) {
-	longDesc := longDescHead + longDescBody + longDescFoot + eksDescNote
+	longDesc := longDescHead + longDescBody + longDescFoot + eksDescNote + aksDescNote
 	useCmd := &cobra.Command{
 		Use:     "use",
 		Short:   shortDesc,
@@ -132,6 +136,8 @@ func createProviderCmd(registration *registry.DiscoveryPluginRegistration) (*cob
 	providerLongDesc := fmt.Sprintf(longDescProviderHead, registration.Name) + longDescBody
 	if registration.Name == "eks" {
 		providerLongDesc += eksDescNote
+	} else if registration.Name == "aks" {
+		providerLongDesc += aksDescNote
 	}
 	providerUsageExample := registration.UsageExample + usageExampleFoot
 

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -79,7 +79,7 @@ specified cluster provider.
 	aksDescNote = `
 * Note: kconnect use aks requires kubelogin and azure cli.
   [kubelogin](https://github.com/Azure/kubelogin)
-  [azure cli](https://docs.microsoft.com/en-us/cli/azure/)
+  [azure-cli](https://github.com/Azure/azure-cli)
 `
 	usageExample = `
   # Connect to EKS and choose an available EKS cluster.

--- a/pkg/plugins/discovery/azure/config.go
+++ b/pkg/plugins/discovery/azure/config.go
@@ -46,12 +46,9 @@ func (p *aksClusterProvider) GetConfig(ctx context.Context, input *discovery.Get
 	}
 	if !p.config.Admin {
 		if p.config.LoginType == LoginTypeToken {
-			if err := p.addTokenToAuthProvider(cfg, input.Identity); err != nil {
-				return nil, fmt.Errorf("adding oauth token to kubeconfig: %w", err)
-			}
-		} else {
-			p.addKubelogin(cfg)
+			p.config.LoginType = LoginTypeAzureCli
 		}
+		p.addKubelogin(cfg)
 		p.printLoginDetails()
 	}
 

--- a/pkg/plugins/discovery/azure/config.go
+++ b/pkg/plugins/discovery/azure/config.go
@@ -28,9 +28,7 @@ import (
 
 	azclient "github.com/fidelity/kconnect/pkg/azure/client"
 	"github.com/fidelity/kconnect/pkg/azure/id"
-	azid "github.com/fidelity/kconnect/pkg/azure/identity"
 	"github.com/fidelity/kconnect/pkg/provider/discovery"
-	"github.com/fidelity/kconnect/pkg/provider/identity"
 )
 
 const (
@@ -107,36 +105,6 @@ func (p *aksClusterProvider) addKubelogin(cfg *api.Config) {
 			Exec: execConfig,
 		},
 	}
-}
-
-func (p *aksClusterProvider) addTokenToAuthProvider(cfg *api.Config, userID identity.Identity) error {
-	id, ok := userID.(*azid.ActiveDirectoryIdentity)
-	if !ok {
-		return ErrTokenNeedsAD
-	}
-
-	contextName := cfg.CurrentContext
-	context := cfg.Contexts[contextName]
-	userName := context.AuthInfo
-	authInfo := cfg.AuthInfos[userName]
-
-	providerConfig := authInfo.AuthProvider.Config
-	apiServerID := providerConfig["apiserver-id"]
-	clientID := providerConfig["client-id"]
-
-	updatedID := id.Clone(azid.WithClientID(clientID))
-
-	token, err := updatedID.GetOAuthToken(apiServerID)
-	if err != nil {
-		return fmt.Errorf("getting oauth token for %s: %w", apiServerID, err)
-	}
-
-	providerConfig["access-token"] = token.AccessToken
-	providerConfig["expires-in"] = token.ExpiresIn.String()
-	providerConfig["expires-on"] = token.ExpiresOn.String()
-	providerConfig["refresh-token"] = token.RefreshToken
-
-	return nil
 }
 
 func (p *aksClusterProvider) getKubeconfig(ctx context.Context, cluster *discovery.Cluster) (*api.Config, error) {

--- a/pkg/plugins/discovery/azure/config.go
+++ b/pkg/plugins/discovery/azure/config.go
@@ -95,8 +95,6 @@ func (p *aksClusterProvider) addKubelogin(cfg *api.Config) {
 			p.config.TenantID,
 			"--login",
 			string(p.config.LoginType),
-			"--server-fqdn-type",
-			p.config.ServerFqdnType,
 		},
 	}
 

--- a/pkg/plugins/discovery/azure/resolver.go
+++ b/pkg/plugins/discovery/azure/resolver.go
@@ -43,8 +43,8 @@ func (p *aksClusterProvider) Validate(cfg config.ConfigurationSet) error {
 	return nil
 }
 
-// Resolve will resolve the values for the AWS specific flags that have no value. It will
-// query AWS and interactively ask the user for selections.
+// Resolve will resolve the values for the Azure specific flags that have no value. It will
+// query Azure and interactively ask the user for selections.
 func (p *aksClusterProvider) Resolve(cfg config.ConfigurationSet, userID identity.Identity) error {
 	if err := p.setup(cfg, userID); err != nil {
 		return fmt.Errorf("setting up aks provider: %w", err)

--- a/pkg/plugins/discovery/azure/types.go
+++ b/pkg/plugins/discovery/azure/types.go
@@ -44,4 +44,6 @@ var (
 	LoginTypeManagedServiceIdentity = LoginType("msi")
 	// LoginTypeToken is for an embedded token login type
 	LoginTypeToken = LoginType("token")
+	// LoginTypeAzureCli is for an using the azurecli to login
+	LoginTypeAzureCli = LoginType("azurecli")
 )

--- a/pkg/plugins/discovery/rancher/resolver.go
+++ b/pkg/plugins/discovery/rancher/resolver.go
@@ -41,8 +41,8 @@ func (p *rancherClusterProvider) Validate(cfg config.ConfigurationSet) error {
 	return nil
 }
 
-// Resolve will resolve the values for the AWS specific flags that have no value. It will
-// query AWS and interactively ask the user for selections.
+// Resolve will resolve the values for the Rancher specific flags that have no value. It will
+// query Rancher and interactively ask the user for selections.
 func (p *rancherClusterProvider) Resolve(cfg config.ConfigurationSet, identity identity.Identity) error {
 	if err := p.setup(cfg, identity); err != nil {
 		return fmt.Errorf("setting up rancher provider: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will resolve the warning message about `the azure auth plugin is deprecated in v1.22+, unavailable in v1.25+`. Once AKS 1.25 comes out we can validate that this change still works, but at least for now the warning message no longer appears.

However, this means that the [Azure CLI](https://github.com/Azure/azure-cli) is now a required dependency for kconnect, and therefore has been added to the `Dockerfile.deps`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #424 