### PR TITLE
fix(scripts): update install-kconnect.sh to not automatically run azure cli install script for linux

### DIFF
--- a/scripts/install-kconnect.sh
+++ b/scripts/install-kconnect.sh
@@ -63,7 +63,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     curl -s -L $helm_url -o helm.tar.gz
     curl -s -L $aws_iam_authenticator_url -o aws-iam-authenticator
     curl -s -L $kubelogin_url -o kubelogin.zip
-    curl -s -L $azure_url | bash
+    curl -s -L $azure_url -o azure-cli-install.sh
 
     # unzip
     tar -xf kconnect.tar.gz
@@ -83,6 +83,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     chmod +x kubectl
     chmod +x aws-iam-authenticator
     chmod +x kubelogin
+    chmod +x azure-cli-install.sh
 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR should fix the issue of the `install-kconnect.sh` not being able to run with no tty for linux users. Instead, Linux users will receive the install script needed to be executed in order to install the Azure CLI. Similar to Windows users with the *.msi file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #436 