### PR TITLE
feat(images): upgrade alpine to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS certs
+FROM alpine:3.17 AS certs
 RUN apk --update add ca-certificates
 RUN adduser -D kconnect
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 RUN apk --no-cache add ca-certificates
 COPY  kconnect /

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS builder
+FROM alpine:3.17 AS builder
 
 ARG AWS_IAM_AUTH_VERSION=0.5.9
 ARG KUBELOGIN_VERSION=0.0.14


### PR DESCRIPTION
**What this PR does / why we need it**: We need to upgrade the base image to alpine version 3.17 as 3.16 will be EOL in Fidelity. 