### PR TITLE
feat(Docker): upgrade Azure CLI image

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -28,7 +28,7 @@ RUN curl -L \
 RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -o helm.tar.gz && \
     tar xvfz helm.tar.gz
 
-FROM mcr.microsoft.com/azure-cli:2.38.0
+FROM mcr.microsoft.com/azure-cli:2.48.1
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /app/


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will upgrade the version of the Azure CLI image that is being used within the `Dockerfile.deps` file. This change is needed in order to upgrade the underlying `alpine` version to `3.17`, and might as well upgrade the Azure CLI version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # OpenSSL 1.1.1 EOL on 9/11/2023

```
% docker run -it --rm --entrypoint bash mcr.microsoft.com/azure-cli:2.48.1
2042604ccd87:/# cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.17.3
PRETTY_NAME="Alpine Linux v3.17"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
2042604ccd87:/# openssl version
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)
```