### PR TITLE
fix(actions): upgrade actions to use node16, and resolve goreleaser deprecations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -8,7 +8,7 @@ jobs:
     name: Verify Docs
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
         submodules: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -32,7 +32,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -46,11 +46,11 @@ jobs:
   #   # Steps represent a sequence of tasks that will be executed as part of the job
   #   steps:
   #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v3
   #       with:
   #         submodules: true
   #     - name: Set up Go
-  #       uses: actions/setup-go@v2
+  #       uses: actions/setup-go@v3
   #       with:
   #         go-version: 1.17
   #     # Run linter

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,18 @@ jobs:
           DOCKER_CLI_EXPERIMENTAL: "enabled"
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   fetch-depth: 0
                   submodules: true
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
+              uses: docker/setup-qemu-action@v2
             - name: Set up Go
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v3
               with:
                   go-version: 1.17
             - name: Login to DockerHub
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                 password: ${{secrets.DKR_TOKEN}}
                 username: ${{secrets.DKR_USER}}
@@ -34,9 +34,9 @@ jobs:
             #   env:
             #     SNAP_TOKEN: ${{secrets.SNAP_LOGIN}}
             - name: Run GoReleaser
-              uses: goreleaser/goreleaser-action@v2
+              uses: goreleaser/goreleaser-action@v3
               with:
                   version: latest
-                  args: release --rm-dist
+                  args: release --clean
               env:
                   GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,9 +30,10 @@ archives:
       id: default
       builds:
         - default
-      name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-      replacements:
-        darwin: macos
+      name_template: >-
+        {{ .ProjectName }}_
+        {{- if eq .Os "darwin" }}macos{{ end }}_
+        {{ .Arch }}
       format: tar.gz
       format_overrides:
           - goos: windows
@@ -55,7 +56,7 @@ changelog:
 
 brews:
   -
-    tap:
+    repository:
       owner: fidelity
       name: homebrew-tap
     homepage: "https://github.com/fidelity/kconnect"
@@ -181,9 +182,10 @@ docker_manifests:
 nfpms:
   -
     package_name: kconnect
-    replacements:
-      darwin: macos
-    file_name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    file_name_template: >-
+        {{ .ProjectName }}_
+        {{- if eq .Os "darwin" }}macos{{ end }}_
+        {{ .Arch }}
     vendor: kconnect authors
     maintainer: Robert Casale <robert.casale@fidelity.com>
     homepage: https://github.com/fidelity/kconnect
@@ -199,9 +201,10 @@ nfpms:
 # snapcrafts:
 #   -
 #     name: kconnect
-#     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-#     replacements:
-#       darwin: macos
+#     name_template: >-
+#        {{ .ProjectName }}_
+#        {{- if eq .Os "darwin" }}macos{{ end }}_
+#        {{ .Arch }}
 #     publish: true
 #     summary: "The Kubernetes Connection Manager CLI"
 #     description: "kconnect is a CLI utility that can be used to discover and securely access Kubernetes clusters across multiple operating environments."


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will update needed changes to `goreleaser`. While trying to create a prerelease, the `goreleaser` failed: https://github.com/fidelity/kconnect/actions/runs/5615976944/job/15217371412#step:6:25

One issue was that we were using deprecated fields: https://goreleaser.com/deprecations/#archivesreplacements

The second issue is that GitHub Actions are going to remove support for `node12`: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Therefore, we needed to upgrade the following GitHub Actions:
- https://github.com/docker/setup-qemu-action/releases/tag/v2.0.0
- https://github.com/actions/setup-go/releases/tag/v3.0.0
- https://github.com/docker/login-action/releases/tag/v2.0.0
- https://github.com/goreleaser/goreleaser-action/releases/tag/v3.0.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [goreleaser #59](https://github.com/fidelity/kconnect/actions/runs/5615976944/job/15217371412#step:6:25)

***This branch can be deleted once it is merged.***