### PR TITLE
fix(actions): upgrade the goreleaser go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v3
               with:
-                  go-version: 1.17
+                  go-version: 1.20
             - name: Login to DockerHub
               uses: docker/login-action@v2
               with:


### PR DESCRIPTION
**What this PR does / why we need it**:
There appears to be some modules that require Go 1.20 during the GoReleaser workflow. This will hopefully fix the error message seeing within the GoReleaser workflow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [goreleaser 60](https://github.com/fidelity/kconnect/actions/runs/5617116378/job/15220664928)

***This branch can be deleted once it is merged.***