### PR TITLE
feat(actions): update the go-version field to use a string instead of a number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v3
               with:
-                  go-version: 1.20
+                  go-version: '1.20'
             - name: Login to DockerHub
               uses: docker/login-action@v2
               with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will fix the issue within the `goreleaser` GitHub Action:
```
⨯ release failed after 0s                  error=hook failed: go mod download: exit status 2; output: go: unknown subcommand "mod"
Run 'go help' for usage.
```

Turns out there is a behavior with YAML where if we provide a number the YAML will be parsed to ignore the trailing zero. Therefore, instead of using `Go1.20`, the GitHub Action was using `Go1.2`:
```
Successfully set up Go version 1.2
##[add-matcher]/home/runner/work/_actions/actions/setup-go/v3/matchers.json
##[debug]Added matchers: 'go'. Problem matchers scan action output for known warning or error strings and report these inline.
go version go1.2.2 linux/amd64
```

I was able to confirm that other users ran into the same issue: https://github.com/actions/setup-go/issues/326#issuecomment-1415636066

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [goreleaser 61](https://github.com/fidelity/kconnect/actions/runs/5617728236/job/15222601115)

***This branch can be deleted once it is merged.***