### PR TITLE
feat(actions): update asset name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,10 +30,7 @@ archives:
       id: default
       builds:
         - default
-      name_template: >-
-        {{ .ProjectName }}_
-        {{- if eq .Os "darwin" }}macos{{ end }}_
-        {{ .Arch }}
+      name_template: '{{ .ProjectName }}_{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
       format: tar.gz
       format_overrides:
           - goos: windows
@@ -182,10 +179,7 @@ docker_manifests:
 nfpms:
   -
     package_name: kconnect
-    file_name_template: >-
-        {{ .ProjectName }}_
-        {{- if eq .Os "darwin" }}macos{{ end }}_
-        {{ .Arch }}
+    file_name_template: '{{ .ProjectName }}_{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
     vendor: kconnect authors
     maintainer: Robert Casale <robert.casale@fidelity.com>
     homepage: https://github.com/fidelity/kconnect


### PR DESCRIPTION
**What this PR does / why we need it**:
This will hopefully fix the naming of the different asset names within the Release section. The asset names are missing the OS. Also, hopefully the extra period will disappear. Currently, I am not sure where that extra period comes from.
```
kconnect_macos_.arm64.tar.gz
kconnect__.amd64.apk
kconnect__.amd64.deb
kconnect__.amd64.rpm
kconnect__.amd64.tar.gz
kconnect__.amd64.zip
kconnect__.arm64.apk
kconnect__.arm64.deb
kconnect__.arm64.rpm
kconnect__.arm64.tar.gz
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

***This branch can be deleted once it is merged.***