### PR TITLE
feat(aws): enable regional endpoint resolving for STS

### DIFF
--- a/pkg/plugins/identity/saml/sp/aws/provider.go
+++ b/pkg/plugins/identity/saml/sp/aws/provider.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 
@@ -266,7 +267,8 @@ func (p *ServiceProvider) getRoleFromPrompt(accounts []*saml2aws.AWSAccount, rol
 
 func (p *ServiceProvider) loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAssertion string) (*awsconfig.AWSCredentials, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region: &account.Region,
+		Region:              &account.Region,
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating aws session: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will enable `regional` endpoint resolving, such that when we call AWS STS we will use the specific region that the user is attempting to connect to instead of the global AWS STS endpoint `https://sts.amazonaws.com`.

Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html

### Testing
Locally built `kconnect` with `make ci`, and was able to connect to a cluster:
```
% ./kconnect use eks
info    kconnect - the Kubernetes Connection Manager CLI        {"version": ""}
info    authenticating user     {"app": "kconnect", "provider": "saml"}
? Select an AWS region eu-central-1
? Username: <username>
? Password: <password>
? Select AWS role Account: <AWS-role>
info    checking svc.Endpoint regional -> https://sts.eu-central-1.amazonaws.com        {"provider": "saml", "sp": "aws"}
info    checking svc.Client.Endpoint regional -> https://sts.eu-central-1.amazonaws.com {"provider": "saml", "sp": "aws"}
info    requesting AWS credentials using SAML   {"provider": "saml", "sp": "aws"}
info    discovering clusters    {"app": "kconnect", "provider": "eks"}
info    discovering EKS clusters        {"app": "kconnect", "provider": "eks"}
? Do you want to set an alias? No
info    Command to reconnect using this alias: kconnect to      {"app": "kconnect"}
info    setting current context {"context": "<context>"}
info    kubeconfig updated      {"path": "/path/to/KUBECONFIG"}
```
As shown in the output we are now using a regional AWS STS endpoint instead of the global one.

Old output:
```
info    checking svc.Endpoint -> https://sts.amazonaws.com      {"provider": "saml", "sp": "aws"}
info    checking svc.Client.Endpoint -> https://sts.amazonaws.com       {"provider": "saml", "sp": "aws"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # In case we have another AWS outage that affects the `us-east-1` region.

***This branch can be deleted once it is merged.***