### PR TITLE
feat: add use oidc cmd

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,6 +1,7 @@
 FROM alpine:3.17 AS builder
 
 ARG AWS_IAM_AUTH_VERSION=0.5.9
+ARG ODIC_LOGIN_VERSION=1.28.0
 ARG KUBELOGIN_VERSION=0.0.14
 ARG KUBECTL_VERSION=1.22.11
 ARG HELM_VERSION=3.9.0
@@ -18,6 +19,13 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TA
 RUN curl -L \
     https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTH_VERSION}/aws-iam-authenticator_${AWS_IAM_AUTH_VERSION}_${TARGETOS}_${TARGETARCH} -o aws-iam-authenticator && \
     chmod +x ./aws-iam-authenticator
+
+# oidclogin
+RUN curl -L \
+    https://github.com/int128/kubelogin/releases/download/v${ODIC_LOGIN_VERSION}/kubelogin_${TARGETOS}_${TARGETARCH}.zip -o oidclogin.zip && \
+    unzip oidclogin.zip  && \
+    mv kubelogin kubectl-oidc_login && \
+    chmod +x ./kubectl-oidc_login
 
 # kubelogin
 RUN curl -L \
@@ -39,6 +47,7 @@ ARG TARGETVARIANT
 
 COPY --from=builder kubectl .
 COPY --from=builder aws-iam-authenticator .
+COPY --from=builder kubectl-oidc_login .
 COPY --from=builder bin/${TARGETOS}_${TARGETARCH}/kubelogin .
 COPY --from=builder ${TARGETOS}-${TARGETARCH}/helm .
 COPY kconnect .

--- a/docs/book/src/commands/use.md
+++ b/docs/book/src/commands/use.md
@@ -33,6 +33,9 @@ specified cluster provider.
   [kubelogin](https://github.com/Azure/kubelogin)
   [azure-cli](https://github.com/Azure/azure-cli)
 
+* Note: kconnect use oidc requires kube-oidc-login and rename to kubectl-oidc_login.
+  [kube-oidc-login](https://github.com/int128/kubelogin)
+
 
 ```bash
 kconnect use [flags]

--- a/docs/book/src/commands/use.md
+++ b/docs/book/src/commands/use.md
@@ -76,6 +76,7 @@ kconnect use [flags]
 * [kconnect](index.md)	 - The Kubernetes Connection Manager CLI
 * [kconnect use aks](use_aks.md)	 - Connect to the aks cluster provider and choose a cluster.
 * [kconnect use eks](use_eks.md)	 - Connect to the eks cluster provider and choose a cluster.
+* [kconnect use oidc](use_oidc.md)	 - Connect to the oidc cluster provider and choose a cluster.
 * [kconnect use rancher](use_rancher.md)	 - Connect to the rancher cluster provider and choose a cluster.
 
 

--- a/docs/book/src/commands/use_oidc.md
+++ b/docs/book/src/commands/use_oidc.md
@@ -19,6 +19,9 @@ entry ID or alias.  When the user reconnects using a connection history entry,
 kconnect regenerates the kubectl configuration context and refreshes their access
 token.
 
+* Note: kconnect use oidc requires kube-oidc-login and rename to kubectl-oidc_login.
+  [kube-oidc-login](https://github.com/int128/kubelogin)
+
 
 ```bash
 kconnect use oidc [flags]

--- a/docs/book/src/commands/use_oidc.md
+++ b/docs/book/src/commands/use_oidc.md
@@ -1,0 +1,104 @@
+## kconnect use oidc
+
+Connect to the oidc cluster provider and choose a cluster.
+
+### Synopsis
+
+
+Connect to oidc via the configured identify provider, prompting the user to enter
+or choose connection settings and a target cluster once connected.
+
+The kconnect tool generates a kubectl configuration context with a fresh access
+token to connect to the chosen cluster and adds a connection history entry to
+store the chosen connection settings.  If given an alias name, kconnect will add
+a user-friendly alias to the new connection history entry.
+
+The user can then reconnect to the provider with the settings stored in the
+connection history entry using the kconnect to command and the connection history
+entry ID or alias.  When the user reconnects using a connection history entry,
+kconnect regenerates the kubectl configuration context and refreshes their access
+token.
+
+
+```bash
+kconnect use oidc [flags]
+```
+
+### Examples
+
+```bash
+
+  # Setup cluster for oidc protocol using default config file
+  kconnect use oidc
+
+  # Setup cluster for oidc protocol using config url
+  kconnect use oidc --config-url https://localhost:8080
+
+  # Setup cluster and add an alias to its connection history entry
+  kconnect use oidc --alias mycluster
+  
+  # Reconnect to a cluster by its connection history entry alias.
+  kconnect to mycluster
+
+  # Display the user's connection history as a table.
+  kconnect ls
+
+```
+
+### Options
+
+```bash
+  -a, --alias string                Friendly name to give to give the connection
+      --ca-cert string              ca cert for configuration url
+      --cluster-auth string         cluster auth data
+  -c, --cluster-id string           Id of the cluster to use.
+      --cluster-url string          cluster api server endpoint
+      --config-url string           configuration endpoint
+  -h, --help                        help for oidc
+      --history-location string     Location of where the history is stored. (default "$HOME/.kconnect/history.yaml")
+      --idp-protocol string         The idp protocol to use (e.g. saml, aad). See flags additional flags for the protocol.
+  -k, --kubeconfig string           Location of the kubeconfig to use. (default "$HOME/.kube/config")
+      --max-history int             Sets the maximum number of history items to keep (default 100)
+  -n, --namespace string            Sets namespace for context in kubeconfig
+      --no-history                  If set to true then no history entry will be written
+      --oidc-client-id string       oidc client id
+      --oidc-client-secret string   oidc client secret
+      --oidc-server string          oidc server url
+      --oidc-use-pkce string        if use pkce
+      --password string             The password to use for authentication
+      --set-current                 Sets the current context in the kubeconfig to the selected cluster (default true)
+      --username string             The username used for authentication
+```
+
+### Options inherited from parent commands
+
+```bash
+      --config string      Configuration file for application wide defaults. (default "$HOME/.kconnect/config.yaml")
+      --no-input           Explicitly disable interactivity when running in a terminal
+      --no-version-check   If set to true kconnect will not check for a newer version
+  -v, --verbosity int      Sets the logging verbosity. Greater than 0 is debug and greater than 9 is trace.
+```
+
+### IDP Protocol Options
+
+#### OIDC Options
+
+Use `--idp-protocol=oidc`
+
+```bash
+      --ca-cert string              ca cert for configuration url
+      --cluster-auth string         cluster auth data
+      --cluster-url string          cluster api server endpoint
+      --config-url string           configuration endpoint
+      --oidc-client-id string       oidc client id
+      --oidc-client-secret string   oidc client secret
+      --oidc-server string          oidc server url
+      --oidc-use-pkce string        if use pkce
+```
+
+### SEE ALSO
+
+* [kconnect use](use.md)	 - Connect to a Kubernetes cluster provider and cluster.
+
+
+> NOTE: this page is auto-generated from the cobra commands

--- a/docs/book/src/commands/use_oidc.md
+++ b/docs/book/src/commands/use_oidc.md
@@ -67,6 +67,7 @@ kconnect use oidc [flags]
       --oidc-use-pkce string        if use pkce
       --password string             The password to use for authentication
       --set-current                 Sets the current context in the kubeconfig to the selected cluster (default true)
+      --skip-ssl string             flag to skip ssl for calling config url
       --username string             The username used for authentication
 ```
 
@@ -94,6 +95,7 @@ Use `--idp-protocol=oidc`
       --oidc-client-secret string   oidc client secret
       --oidc-server string          oidc server url
       --oidc-use-pkce string        if use pkce
+      --skip-ssl string             flag to skip ssl for calling config url
 ```
 
 ### SEE ALSO

--- a/docs/book/src/commands/use_oidc.md
+++ b/docs/book/src/commands/use_oidc.md
@@ -67,6 +67,7 @@ kconnect use oidc [flags]
       --oidc-use-pkce string        if use pkce
       --password string             The password to use for authentication
       --set-current                 Sets the current context in the kubeconfig to the selected cluster (default true)
+      --skip-oidc-ssl string        flag to skip ssl for calling oidc server
       --skip-ssl string             flag to skip ssl for calling config url
       --username string             The username used for authentication
 ```
@@ -95,6 +96,7 @@ Use `--idp-protocol=oidc`
       --oidc-client-secret string   oidc client secret
       --oidc-server string          oidc server url
       --oidc-use-pkce string        if use pkce
+      --skip-oidc-ssl string        flag to skip ssl for calling oidc server
       --skip-ssl string             flag to skip ssl for calling config url
 ```
 

--- a/internal/commands/use/use.go
+++ b/internal/commands/use/use.go
@@ -83,6 +83,10 @@ specified cluster provider.
   [kubelogin](https://github.com/Azure/kubelogin)
   [azure-cli](https://github.com/Azure/azure-cli)
 `
+	oidcDescNote = `
+* Note: kconnect use oidc requires kube-oidc-login and rename to kubectl-oidc_login.
+  [kube-oidc-login](https://github.com/int128/kubelogin)
+`
 	usageExample = `
   # Connect to EKS and choose an available EKS cluster.
   {{.CommandPath}} use eks
@@ -101,7 +105,7 @@ specified cluster provider.
 
 // Command creates the use command
 func Command() (*cobra.Command, error) {
-	longDesc := longDescHead + longDescBody + longDescFoot + eksDescNote + aksDescNote
+	longDesc := longDescHead + longDescBody + longDescFoot + eksDescNote + aksDescNote + oidcDescNote
 	useCmd := &cobra.Command{
 		Use:     "use",
 		Short:   shortDesc,
@@ -140,6 +144,8 @@ func createProviderCmd(registration *registry.DiscoveryPluginRegistration) (*cob
 		providerLongDesc += eksDescNote
 	} else if registration.Name == "aks" {
 		providerLongDesc += aksDescNote
+	} else if registration.Name == "oidc" {
+		providerLongDesc += oidcDescNote
 	}
 	providerUsageExample := registration.UsageExample + usageExampleFoot
 

--- a/pkg/oidc/config.go
+++ b/pkg/oidc/config.go
@@ -17,7 +17,10 @@ limitations under the License.
 package oidc
 
 import (
+	"fmt"
+
 	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/prompt"
 )
 
 const (
@@ -39,6 +42,8 @@ const (
 	ConfigUrlConfigDescription   = "configuration endpoint"
 	CaCertConfigItem             = "ca-cert"
 	CaCertConfigDescription      = "ca cert for configuration url"
+	SkipTlsVerifyConfigItem      = "skip-ssl"
+	SkipTlsVerifyDescription     = "flag to skip ssl for calling config url"
 )
 
 // SharedConfig will return shared configuration items for OIDC based cluster and identity providers
@@ -52,6 +57,15 @@ func SharedConfig() config.ConfigurationSet {
 	cs.String(ClusterAuthConfigItem, "", ClusterAuthConfigDescription) //nolint: errcheck
 	cs.String(ConfigUrlConfigItem, "", ConfigUrlConfigDescription)     //nolint: errcheck
 	cs.String(CaCertConfigItem, "", CaCertConfigDescription)           //nolint: errcheck
+	cs.String(SkipTlsVerifyConfigItem, "", SkipTlsVerifyDescription)   //nolint: errcheck
 
 	return cs
+}
+
+func ReadUserInput(key string, msg string) (string, error) {
+	userInput, err := prompt.Input(key, msg, false)
+	if userInput == "" || err != nil {
+		return userInput, fmt.Errorf("error reading input for %s", key)
+	}
+	return userInput, nil
 }

--- a/pkg/oidc/config.go
+++ b/pkg/oidc/config.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"github.com/fidelity/kconnect/pkg/config"
+)
+
+const (
+	OidcServerConfigItem         = "oidc-server"
+	OidcServerConfigDescription  = "oidc server url"
+	OidcIdConfigItem             = "oidc-client-id"
+	OidcIdConfigDescription      = "oidc client id"
+	OidcSecretConfigItem         = "oidc-client-secret"
+	OidcSecretConfigDescription  = "oidc client secret"
+	UsePkceConfigItem            = "oidc-use-pkce"
+	UsePkceConfigDescription     = "if use pkce"
+	ClusterIdConfigItem          = "cluster-id"
+	ClusterIdConfigDescription   = "cluster id"
+	ClusterUrlConfigItem         = "cluster-url"
+	ClusterUrlConfigDescription  = "cluster api server endpoint"
+	ClusterAuthConfigItem        = "cluster-auth"
+	ClusterAuthConfigDescription = "cluster auth data"
+	ConfigUrlConfigItem          = "config-url"
+	ConfigUrlConfigDescription   = "configuration endpoint"
+	CaCertConfigItem             = "ca-cert"
+	CaCertConfigDescription      = "ca cert for configuration url"
+)
+
+// SharedConfig will return shared configuration items for OIDC based cluster and identity providers
+func SharedConfig() config.ConfigurationSet {
+	cs := config.NewConfigurationSet()
+	cs.String(OidcServerConfigItem, "", OidcServerConfigDescription)   //nolint: errcheck
+	cs.String(OidcIdConfigItem, "", OidcIdConfigDescription)           //nolint: errcheck
+	cs.String(OidcSecretConfigItem, "", OidcSecretConfigDescription)   //nolint: errcheck
+	cs.String(UsePkceConfigItem, "", UsePkceConfigDescription)         //nolint: errcheck
+	cs.String(ClusterUrlConfigItem, "", ClusterUrlConfigDescription)   //nolint: errcheck
+	cs.String(ClusterAuthConfigItem, "", ClusterAuthConfigDescription) //nolint: errcheck
+	cs.String(ConfigUrlConfigItem, "", ConfigUrlConfigDescription)     //nolint: errcheck
+	cs.String(CaCertConfigItem, "", CaCertConfigDescription)           //nolint: errcheck
+
+	return cs
+}

--- a/pkg/oidc/config.go
+++ b/pkg/oidc/config.go
@@ -44,20 +44,23 @@ const (
 	CaCertConfigDescription      = "ca cert for configuration url"
 	SkipTlsVerifyConfigItem      = "skip-ssl"
 	SkipTlsVerifyDescription     = "flag to skip ssl for calling config url"
+	SkipOidcTlsVerifyConfigItem  = "skip-oidc-ssl"
+	SkipOidcTlsVerifyDescription = "flag to skip ssl for calling oidc server"
 )
 
 // SharedConfig will return shared configuration items for OIDC based cluster and identity providers
 func SharedConfig() config.ConfigurationSet {
 	cs := config.NewConfigurationSet()
-	cs.String(OidcServerConfigItem, "", OidcServerConfigDescription)   //nolint: errcheck
-	cs.String(OidcIdConfigItem, "", OidcIdConfigDescription)           //nolint: errcheck
-	cs.String(OidcSecretConfigItem, "", OidcSecretConfigDescription)   //nolint: errcheck
-	cs.String(UsePkceConfigItem, "", UsePkceConfigDescription)         //nolint: errcheck
-	cs.String(ClusterUrlConfigItem, "", ClusterUrlConfigDescription)   //nolint: errcheck
-	cs.String(ClusterAuthConfigItem, "", ClusterAuthConfigDescription) //nolint: errcheck
-	cs.String(ConfigUrlConfigItem, "", ConfigUrlConfigDescription)     //nolint: errcheck
-	cs.String(CaCertConfigItem, "", CaCertConfigDescription)           //nolint: errcheck
-	cs.String(SkipTlsVerifyConfigItem, "", SkipTlsVerifyDescription)   //nolint: errcheck
+	cs.String(OidcServerConfigItem, "", OidcServerConfigDescription)         //nolint: errcheck
+	cs.String(OidcIdConfigItem, "", OidcIdConfigDescription)                 //nolint: errcheck
+	cs.String(OidcSecretConfigItem, "", OidcSecretConfigDescription)         //nolint: errcheck
+	cs.String(UsePkceConfigItem, "", UsePkceConfigDescription)               //nolint: errcheck
+	cs.String(ClusterUrlConfigItem, "", ClusterUrlConfigDescription)         //nolint: errcheck
+	cs.String(ClusterAuthConfigItem, "", ClusterAuthConfigDescription)       //nolint: errcheck
+	cs.String(ConfigUrlConfigItem, "", ConfigUrlConfigDescription)           //nolint: errcheck
+	cs.String(CaCertConfigItem, "", CaCertConfigDescription)                 //nolint: errcheck
+	cs.String(SkipTlsVerifyConfigItem, "", SkipTlsVerifyDescription)         //nolint: errcheck
+	cs.String(SkipOidcTlsVerifyConfigItem, "", SkipOidcTlsVerifyDescription) //nolint: errcheck
 
 	return cs
 }

--- a/pkg/oidc/identity.go
+++ b/pkg/oidc/identity.go
@@ -20,10 +20,11 @@ const Oidc = "oidc"
 
 // Identity represents an oidc identity
 type Identity struct {
-	OidcServer string
-	OidcId     string
-	OidcSecret string
-	UsePkce    string
+	OidcServer        string
+	OidcId            string
+	OidcSecret        string
+	UsePkce           string
+	SkipOidcTlsVerify string
 }
 
 func (i *Identity) Type() string {

--- a/pkg/oidc/identity.go
+++ b/pkg/oidc/identity.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package oidc
 
+const Oidc = "oidc"
+
 // Identity represents an oidc identity
 type Identity struct {
 	OidcServer string
@@ -25,11 +27,11 @@ type Identity struct {
 }
 
 func (i *Identity) Type() string {
-	return "oidc"
+	return Oidc
 }
 
 func (i *Identity) Name() string {
-	return "oidc"
+	return Oidc
 }
 
 func (i *Identity) IsExpired() bool {
@@ -37,5 +39,5 @@ func (i *Identity) IsExpired() bool {
 }
 
 func (i *Identity) IdentityProviderName() string {
-	return "oidc"
+	return Oidc
 }

--- a/pkg/oidc/identity.go
+++ b/pkg/oidc/identity.go
@@ -14,12 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package discovery
+package oidc
 
-import (
-	// Initialize the discovery plugins
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/aws"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/azure"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/oidc"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/rancher"
-)
+// Identity represents an oidc identity
+type Identity struct {
+	OidcServer string
+	OidcId     string
+	OidcSecret string
+	UsePkce    string
+}
+
+func (i *Identity) Type() string {
+	return "oidc"
+}
+
+func (i *Identity) Name() string {
+	return "oidc"
+}
+
+func (i *Identity) IsExpired() bool {
+	return true
+}
+
+func (i *Identity) IdentityProviderName() string {
+	return "oidc"
+}

--- a/pkg/plugins/discovery/oidc/config.go
+++ b/pkg/plugins/discovery/oidc/config.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/fidelity/kconnect/pkg/oidc"
+	"github.com/fidelity/kconnect/pkg/provider/discovery"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func (p *oidcClusterProvider) GetConfig(ctx context.Context, input *discovery.GetConfigInput) (*discovery.GetConfigOutput, error) {
+
+	clusterName := input.Cluster.Name
+	userName := p.identity.OidcId
+	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
+
+	certData, err := base64.StdEncoding.DecodeString(*input.Cluster.CertificateAuthorityData)
+	if err != nil {
+		return nil, fmt.Errorf("decoding certificate: %w", err)
+	}
+
+	oidcID, _ := input.Identity.(*oidc.Identity)
+
+	cfg := &api.Config{
+		Clusters: map[string]*api.Cluster{
+			clusterName: {
+				Server:                   *input.Cluster.ControlPlaneEndpoint,
+				CertificateAuthorityData: certData,
+			},
+		},
+		Contexts: map[string]*api.Context{
+			contextName: {
+				Cluster:  clusterName,
+				AuthInfo: userName,
+			},
+		},
+	}
+
+	args := []string{
+		"oidc-login",
+		"get-token",
+		"--oidc-issuer-url=oidc-server",
+		"--oidc-client-id=" + oidcID.OidcId,
+	}
+
+	if oidcID.UsePkce == "true" {
+		args = append(args, "--oidc-use-pkce")
+	} else {
+		args = append(args, "--oidc-client-secret="+oidcID.OidcSecret)
+	}
+	args = append(args, "--insecure-skip-tls-verify")
+
+	execConfig := &api.ExecConfig{
+		APIVersion:      "client.authentication.k8s.io/v1beta1",
+		Command:         "kubectl",
+		Args:            args,
+		InteractiveMode: api.IfAvailableExecInteractiveMode,
+	}
+
+	cfg.AuthInfos = map[string]*api.AuthInfo{
+		userName: {
+			Exec: execConfig,
+		},
+	}
+
+	cfg.CurrentContext = contextName
+
+	return &discovery.GetConfigOutput{
+		KubeConfig:  cfg,
+		ContextName: &contextName,
+	}, nil
+}

--- a/pkg/plugins/discovery/oidc/config.go
+++ b/pkg/plugins/discovery/oidc/config.go
@@ -59,7 +59,7 @@ func (p *oidcClusterProvider) GetConfig(ctx context.Context, input *discovery.Ge
 	args := []string{
 		"oidc-login",
 		"get-token",
-		"--oidc-issuer-url=oidc-server",
+		"--oidc-issuer-url=" + oidcID.OidcServer,
 		"--oidc-client-id=" + oidcID.OidcId,
 	}
 

--- a/pkg/plugins/discovery/oidc/config.go
+++ b/pkg/plugins/discovery/oidc/config.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
+const True = "true"
+
 func (p *oidcClusterProvider) GetConfig(ctx context.Context, input *discovery.GetConfigInput) (*discovery.GetConfigOutput, error) {
 
 	clusterName := input.Cluster.Name
@@ -61,7 +63,7 @@ func (p *oidcClusterProvider) GetConfig(ctx context.Context, input *discovery.Ge
 		"--oidc-client-id=" + oidcID.OidcId,
 	}
 
-	if oidcID.UsePkce == "true" {
+	if oidcID.UsePkce == True {
 		args = append(args, "--oidc-use-pkce")
 	} else {
 		args = append(args, "--oidc-client-secret="+oidcID.OidcSecret)

--- a/pkg/plugins/discovery/oidc/config.go
+++ b/pkg/plugins/discovery/oidc/config.go
@@ -68,7 +68,9 @@ func (p *oidcClusterProvider) GetConfig(ctx context.Context, input *discovery.Ge
 	} else {
 		args = append(args, "--oidc-client-secret="+oidcID.OidcSecret)
 	}
-	args = append(args, "--insecure-skip-tls-verify")
+	if oidcID.SkipOidcTlsVerify == True {
+		args = append(args, "--insecure-skip-tls-verify")
+	}
 
 	execConfig := &api.ExecConfig{
 		APIVersion:      "client.authentication.k8s.io/v1beta1",

--- a/pkg/plugins/discovery/oidc/discover.go
+++ b/pkg/plugins/discovery/oidc/discover.go
@@ -14,12 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package discovery
+package oidc
 
 import (
-	// Initialize the discovery plugins
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/aws"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/azure"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/oidc"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/rancher"
+	"context"
+
+	"github.com/fidelity/kconnect/pkg/provider/discovery"
 )
+
+func (p *oidcClusterProvider) Discover(ctx context.Context, input *discovery.DiscoverInput) (*discovery.DiscoverOutput, error) {
+
+	cluster, _ := p.getCluster(ctx)
+	clusters := make(map[string]*discovery.Cluster)
+	clusters[cluster.ID] = cluster
+	discoverOutput := &discovery.DiscoverOutput{
+		DiscoveryProvider: ProviderName,
+		IdentityProvider:  "oidc",
+		Clusters:          clusters,
+	}
+
+	return discoverOutput, nil
+}

--- a/pkg/plugins/discovery/oidc/get.go
+++ b/pkg/plugins/discovery/oidc/get.go
@@ -14,12 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package discovery
+package oidc
 
 import (
-	// Initialize the discovery plugins
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/aws"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/azure"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/oidc"
-	_ "github.com/fidelity/kconnect/pkg/plugins/discovery/rancher"
+	"context"
+
+	"github.com/fidelity/kconnect/pkg/provider/discovery"
 )
+
+func (p *oidcClusterProvider) GetCluster(ctx context.Context, input *discovery.GetClusterInput) (*discovery.GetClusterOutput, error) {
+	cluster, _ := p.getCluster(ctx)
+	return &discovery.GetClusterOutput{
+		Cluster: cluster,
+	}, nil
+}

--- a/pkg/plugins/discovery/oidc/provider.go
+++ b/pkg/plugins/discovery/oidc/provider.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/oidc"
+	"github.com/fidelity/kconnect/pkg/prompt"
+	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/provider/common"
+	"github.com/fidelity/kconnect/pkg/provider/discovery"
+	"github.com/fidelity/kconnect/pkg/provider/identity"
+	"github.com/fidelity/kconnect/pkg/provider/registry"
+	"go.uber.org/zap"
+)
+
+const (
+	ProviderName = "oidc"
+	UsageExample = `
+  # Setup cluster for oidc protocol using default config file
+  {{.CommandPath}} use oidc
+
+  # Setup cluster for oidc protocol using config url
+  {{.CommandPath}} use oidc --config-url https://localhost:8080
+
+  # Setup cluster and add an alias to its connection history entry
+  {{.CommandPath}} use oidc --alias mycluster
+  `
+)
+
+func init() {
+	if err := registry.RegisterDiscoveryPlugin(&registry.DiscoveryPluginRegistration{
+		PluginRegistration: registry.PluginRegistration{
+			Name:                   ProviderName,
+			UsageExample:           UsageExample,
+			ConfigurationItemsFunc: ConfigurationItems,
+		},
+		CreateFunc:                 New,
+		SupportedIdentityProviders: []string{"oidc"},
+	}); err != nil {
+		zap.S().Fatalw("Failed to register OIDC discovery plugin", "error", err)
+	}
+}
+
+// New will create a new OIDC discovery plugin
+func New(input *provider.PluginCreationInput) (discovery.Provider, error) {
+	return &oidcClusterProvider{
+		logger: input.Logger,
+	}, nil
+}
+
+type oidcClusterProviderConfig struct {
+	common.ClusterProviderConfig
+	ClusterUrl  string `json:"cluster-url"`
+	ClusterAuth string `json:"cluster-auth"`
+	ConfigUrl   string `json:"config-url"`
+	ConfigCA    string `json:"ca-cert"`
+}
+
+// oidcClusterProvider will generate OIDC config
+type oidcClusterProvider struct {
+	config   *oidcClusterProviderConfig
+	identity *oidc.Identity
+	logger   *zap.SugaredLogger
+}
+
+// Name returns the name of the provider
+func (p *oidcClusterProvider) Name() string {
+	return ProviderName
+}
+
+func (p *oidcClusterProvider) setup(cs config.ConfigurationSet, userID identity.Identity) error {
+	cfg := &oidcClusterProviderConfig{}
+	if err := config.Unmarshall(cs, cfg); err != nil {
+		return fmt.Errorf("unmarshalling config items into oidcClusterProviderConfig: %w", err)
+	}
+	p.config = cfg
+
+	oidcID, ok := userID.(*oidc.Identity)
+	if !ok {
+		return fmt.Errorf("unmarshalling config items into oidcClusterProviderConfig")
+	}
+	p.identity = oidcID
+
+	if err := p.readRequiredFields(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// For required parameter, if not exists in default config file or config url, read user input.
+func (p *oidcClusterProvider) readRequiredFields() error {
+
+	if p.identity.OidcId == "" {
+		value, err := readUserInput(oidc.OidcIdConfigItem, oidc.OidcIdConfigDescription)
+		if err != nil {
+			return err
+		}
+		p.identity.OidcId = value
+	}
+
+	if p.identity.OidcServer == "" {
+		value, err := readUserInput(oidc.OidcServerConfigItem, oidc.OidcServerConfigDescription)
+		if err != nil {
+			return err
+		}
+		p.identity.OidcServer = value
+	}
+
+	if p.identity.UsePkce == "" && p.identity.OidcSecret == "" {
+		value, err := readUserInput(oidc.OidcSecretConfigItem, oidc.OidcSecretConfigDescription)
+		if err != nil {
+			return err
+		}
+		p.identity.OidcSecret = value
+	}
+
+	if p.config.ClusterUrl == "" {
+		value, err := readUserInput(oidc.ClusterUrlConfigItem, oidc.ClusterUrlConfigDescription)
+		if err != nil {
+			return err
+		}
+		p.config.ClusterUrl = value
+	}
+
+	if p.config.ClusterAuth == "" {
+		value, err := readUserInput(oidc.ClusterAuthConfigItem, oidc.ClusterAuthConfigDescription)
+		if err != nil {
+			return err
+		}
+		p.config.ClusterAuth = value
+	}
+
+	if *p.config.ClusterID == "" {
+		value, err := readUserInput(oidc.ClusterIdConfigItem, oidc.ClusterIdConfigDescription)
+		if err != nil {
+			return err
+		}
+		p.config.ClusterID = &value
+	}
+
+	return nil
+
+}
+
+func readUserInput(key string, msg string) (string, error) {
+	userInput, err := prompt.Input(key, msg, false)
+	if userInput == "" || err != nil {
+		return userInput, fmt.Errorf("error reading input for %s", key)
+	}
+	return userInput, nil
+}
+
+func (p *oidcClusterProvider) ListPreReqs() []*provider.PreReq {
+	return []*provider.PreReq{}
+}
+
+func (p *oidcClusterProvider) CheckPreReqs() error {
+	return nil
+}
+
+// ConfigurationItems returns the configuration items for this provider
+func ConfigurationItems(scopeTo string) (config.ConfigurationSet, error) {
+	return oidc.SharedConfig(), nil
+}
+
+func (p *oidcClusterProvider) getCluster(ctx context.Context) (*discovery.Cluster, error) {
+	cluster := discovery.Cluster{
+		ID:                       *p.config.ClusterID,
+		Name:                     *p.config.ClusterID,
+		ControlPlaneEndpoint:     &p.config.ClusterUrl,
+		CertificateAuthorityData: &p.config.ClusterAuth,
+	}
+	return &cluster, nil
+}

--- a/pkg/plugins/discovery/oidc/provider.go
+++ b/pkg/plugins/discovery/oidc/provider.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/fidelity/kconnect/pkg/config"
 	"github.com/fidelity/kconnect/pkg/oidc"
-	"github.com/fidelity/kconnect/pkg/prompt"
 	"github.com/fidelity/kconnect/pkg/provider"
 	"github.com/fidelity/kconnect/pkg/provider/common"
 	"github.com/fidelity/kconnect/pkg/provider/discovery"
 	"github.com/fidelity/kconnect/pkg/provider/identity"
 	"github.com/fidelity/kconnect/pkg/provider/registry"
+	"github.com/fidelity/kconnect/pkg/utils"
 	"go.uber.org/zap"
 )
 
@@ -123,32 +123,8 @@ func (p *oidcClusterProvider) logParameters() {
 // For required parameter, if not exists in default config file or config url, read user input.
 func (p *oidcClusterProvider) readRequiredFields() error {
 
-	if p.identity.OidcId == "" {
-		value, err := readUserInput(oidc.OidcIdConfigItem, oidc.OidcIdConfigDescription)
-		if err != nil {
-			return err
-		}
-		p.identity.OidcId = value
-	}
-
-	if p.identity.OidcServer == "" {
-		value, err := readUserInput(oidc.OidcServerConfigItem, oidc.OidcServerConfigDescription)
-		if err != nil {
-			return err
-		}
-		p.identity.OidcServer = value
-	}
-
-	if p.identity.UsePkce != True && p.identity.OidcSecret == "" {
-		value, err := readUserInput(oidc.OidcSecretConfigItem, oidc.OidcSecretConfigDescription)
-		if err != nil {
-			return err
-		}
-		p.identity.OidcSecret = value
-	}
-
 	if p.config.ClusterUrl == "" {
-		value, err := readUserInput(oidc.ClusterUrlConfigItem, oidc.ClusterUrlConfigDescription)
+		value, err := oidc.ReadUserInput(oidc.ClusterUrlConfigItem, oidc.ClusterUrlConfigDescription)
 		if err != nil {
 			return err
 		}
@@ -156,7 +132,7 @@ func (p *oidcClusterProvider) readRequiredFields() error {
 	}
 
 	if p.config.ClusterAuth == "" {
-		value, err := readUserInput(oidc.ClusterAuthConfigItem, oidc.ClusterAuthConfigDescription)
+		value, err := oidc.ReadUserInput(oidc.ClusterAuthConfigItem, oidc.ClusterAuthConfigDescription)
 		if err != nil {
 			return err
 		}
@@ -164,7 +140,7 @@ func (p *oidcClusterProvider) readRequiredFields() error {
 	}
 
 	if *p.config.ClusterID == "" {
-		value, err := readUserInput(oidc.ClusterIdConfigItem, oidc.ClusterIdConfigDescription)
+		value, err := oidc.ReadUserInput(oidc.ClusterIdConfigItem, oidc.ClusterIdConfigDescription)
 		if err != nil {
 			return err
 		}
@@ -175,20 +151,12 @@ func (p *oidcClusterProvider) readRequiredFields() error {
 
 }
 
-func readUserInput(key string, msg string) (string, error) {
-	userInput, err := prompt.Input(key, msg, false)
-	if userInput == "" || err != nil {
-		return userInput, fmt.Errorf("error reading input for %s", key)
-	}
-	return userInput, nil
-}
-
 func (p *oidcClusterProvider) ListPreReqs() []*provider.PreReq {
 	return []*provider.PreReq{}
 }
 
 func (p *oidcClusterProvider) CheckPreReqs() error {
-	return nil
+	return utils.CheckKubectlOidcLoginPrereq()
 }
 
 // ConfigurationItems returns the configuration items for this provider

--- a/pkg/plugins/discovery/oidc/provider.go
+++ b/pkg/plugins/discovery/oidc/provider.go
@@ -102,8 +102,22 @@ func (p *oidcClusterProvider) setup(cs config.ConfigurationSet, userID identity.
 	if err := p.readRequiredFields(); err != nil {
 		return err
 	}
+	p.logParameters()
 
 	return nil
+}
+
+func (p *oidcClusterProvider) logParameters() {
+
+	p.logger.Infof("Using oidc-server-url: %s.", p.identity.OidcServer)
+	p.logger.Infof("Using oidc-client-id: %s.", p.identity.OidcId)
+	if p.identity.UsePkce == True {
+		p.logger.Infof("using pkce.")
+	}
+	p.logger.Infof("Using cluster-id: %s.", *p.config.ClusterID)
+	p.logger.Infof("Using cluster-url: %s.", p.config.ClusterUrl)
+	p.logger.Infof("Using cluster-auth: %s.", p.config.ClusterAuth)
+
 }
 
 // For required parameter, if not exists in default config file or config url, read user input.
@@ -125,7 +139,7 @@ func (p *oidcClusterProvider) readRequiredFields() error {
 		p.identity.OidcServer = value
 	}
 
-	if p.identity.UsePkce == "" && p.identity.OidcSecret == "" {
+	if p.identity.UsePkce != True && p.identity.OidcSecret == "" {
 		value, err := readUserInput(oidc.OidcSecretConfigItem, oidc.OidcSecretConfigDescription)
 		if err != nil {
 			return err

--- a/pkg/plugins/discovery/oidc/resolver.go
+++ b/pkg/plugins/discovery/oidc/resolver.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The kconnect Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"fmt"
+
+	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/provider/identity"
+)
+
+func (p *oidcClusterProvider) Validate(cfg config.ConfigurationSet) error {
+	return nil
+}
+
+// Resolve will resolve the values for the OIDC specific flags that have no value. It will
+// read config file and interactively ask the user for selections.
+func (p *oidcClusterProvider) Resolve(config config.ConfigurationSet, userID identity.Identity) error {
+	if err := p.setup(config, userID); err != nil {
+		return fmt.Errorf("setting up oidc provider: %w", err)
+	}
+	return nil
+}

--- a/pkg/plugins/identity/oidc/provider.go
+++ b/pkg/plugins/identity/oidc/provider.go
@@ -178,29 +178,13 @@ func (p *oidcIdentityProvider) getConfigFromUrl(configSet config.ConfigurationSe
 }
 
 func readConfigs(p *oidcIdentityProvider, configSet config.ConfigurationSet, configValue string) {
-	skipSsl := false
-	if configSet.Get("skip-ssl") != nil {
-		skip := configSet.Get("skip-ssl").Value
-		if skip != nil {
-			if skip.(string) == True {
-				skipSsl = true
-			}
-		}
-	}
-	if skipSsl {
+	if getValue(configSet, "skip-ssl") == True {
 		SetTransport("")
 	} else {
-		readCa := false
-		if configSet.Get("ca-cert") != nil {
-			caCert := configSet.Get("ca-cert").Value
-			if caCert != nil {
-				if caCert.(string) != "" {
-					readCa = true
-					SetTransport(caCert.(string))
-				}
-			}
-		}
-		if !readCa {
+		caCert := getValue(configSet, "ca-cert")
+		if caCert != "" {
+			SetTransport(caCert)
+		} else {
 			p.logger.Errorf("CA cert is required to call the config url.")
 			return
 		}
@@ -254,6 +238,16 @@ func SetTransport(file string) {
 		config = &tls.Config{InsecureSkipVerify: true}
 	}
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = config
+}
+
+func getValue(configSet config.ConfigurationSet, key string) (value string) {
+	if configSet.Get(key) != nil {
+		val := configSet.Get(key).Value
+		if val != nil {
+			value = val.(string)
+		}
+	}
+	return
 }
 
 // ConfigurationItems will return the configuration items for the identity plugin based

--- a/pkg/plugins/identity/oidc/provider.go
+++ b/pkg/plugins/identity/oidc/provider.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 The kconnect Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/fidelity/kconnect/pkg/config"
+	"github.com/fidelity/kconnect/pkg/oidc"
+	"github.com/fidelity/kconnect/pkg/provider"
+	"github.com/fidelity/kconnect/pkg/provider/identity"
+	"github.com/fidelity/kconnect/pkg/provider/registry"
+
+	kconnectv1alpha "github.com/fidelity/kconnect/api/v1alpha1"
+	khttp "github.com/fidelity/kconnect/pkg/http"
+)
+
+const (
+	ProviderName = "oidc"
+)
+
+func init() {
+	if err := registry.RegisterIdentityPlugin(&registry.IdentityPluginRegistration{
+		PluginRegistration: registry.PluginRegistration{
+			Name:                   ProviderName,
+			UsageExample:           "",
+			ConfigurationItemsFunc: ConfigurationItems,
+		},
+		CreateFunc: New,
+	}); err != nil {
+		zap.S().Fatalw("Failed to register OIDC identity plugin", "error", err)
+	}
+}
+
+// New will create a new OIDC identity provider
+func New(input *provider.PluginCreationInput) (identity.Provider, error) {
+	return &oidcIdentityProvider{
+		logger:      input.Logger,
+		interactive: input.IsInteractice,
+	}, nil
+}
+
+type oidcIdentityProvider struct {
+	logger      *zap.SugaredLogger
+	interactive bool
+}
+
+type providerConfig struct {
+	OidcServer string `json:"oidc-server"`
+	OidcId     string `json:"oidc-client-id"`
+	OidcSecret string `json:"oidc-client-secret"`
+	UsePkce    string `json:"oidc-use-pkce"`
+}
+
+func (p *oidcIdentityProvider) Name() string {
+	return ProviderName
+}
+
+// Authenticate will generate authentication config.
+func (p *oidcIdentityProvider) Authenticate(ctx context.Context, input *identity.AuthenticateInput) (*identity.AuthenticateOutput, error) {
+	p.logger.Info("using oidc for authentication")
+
+	p.getConfigFromUrl(input.ConfigSet)
+
+	cfg := &providerConfig{}
+	if err := config.Unmarshall(input.ConfigSet, cfg); err != nil {
+		return nil, fmt.Errorf("unmarshalling config into providerConfig: %w", err)
+	}
+
+	id := &oidc.Identity{
+		OidcServer: cfg.OidcServer,
+		OidcId:     cfg.OidcId,
+		OidcSecret: cfg.OidcSecret,
+		UsePkce:    cfg.UsePkce,
+	}
+
+	return &identity.AuthenticateOutput{
+		Identity: id,
+	}, nil
+}
+
+func (p *oidcIdentityProvider) getConfigFromUrl(configSet config.ConfigurationSet) {
+	if configSet.Get("config-url") != nil {
+		config := configSet.Get("config-url").Value
+		if config != nil {
+			configValue := config.(string)
+			if strings.HasPrefix(configValue, "http://") {
+				if configSet.Get("ca-cert") != nil {
+					caCert := configSet.Get("ca-cert").Value
+					if caCert != nil {
+						SetTransport(caCert.(string))
+					}
+				} else {
+					SetTransport("")
+				}
+
+				kclient := khttp.NewHTTPClient()
+				res, err := kclient.Get(configValue, nil)
+				if err == nil {
+					appConfiguration := &kconnectv1alpha.Configuration{}
+					if err := json.Unmarshal([]byte(res.Body()), appConfiguration); err == nil {
+						oidc := appConfiguration.Spec.Providers["oidc"]
+						for k, v := range oidc {
+							if k != "" && v != "" {
+								addItem(configSet, k, v)
+							}
+						}
+					} else {
+						p.logger.Errorf("Error loading payload from config URL, error is: %w", err)
+					}
+				} else {
+					p.logger.Errorf("Error calling config URL, error is: %w", err)
+				}
+			}
+		}
+	}
+
+}
+
+func addItem(configSet config.ConfigurationSet, key string, value string) {
+	if configSet.Exists(key) {
+		configSet.SetValue(key, value)
+	} else {
+		configSet.Add(
+			&config.Item{Name: key, Type: config.ItemType("string"), Value: value, DefaultValue: ""})
+	}
+}
+
+func SetTransport(file string) {
+
+	var config *tls.Config
+	if file != "" {
+		caCert, err := os.ReadFile(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		config = &tls.Config{
+			RootCAs: caCertPool,
+		}
+	} else {
+		config = &tls.Config{InsecureSkipVerify: true}
+	}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = config
+}
+
+// ConfigurationItems will return the configuration items for the identity plugin based
+// of the cluster provider that its being used in conjunction with
+func ConfigurationItems(scopeTo string) (config.ConfigurationSet, error) {
+	cs := oidc.SharedConfig()
+	return cs, nil
+}

--- a/pkg/plugins/identity/oidc/provider.go
+++ b/pkg/plugins/identity/oidc/provider.go
@@ -231,6 +231,11 @@ func addItem(configSet config.ConfigurationSet, key string, value string) {
 func SetTransport(file string) {
 
 	var config *tls.Config
+	skipReadCert := false
+	if file == "" {
+		skipReadCert = true
+	}
+
 	if file != "" {
 		caCert, err := os.ReadFile(file)
 		if err != nil {
@@ -242,7 +247,7 @@ func SetTransport(file string) {
 			RootCAs: caCertPool,
 		}
 	} else {
-		config = &tls.Config{InsecureSkipVerify: true}
+		config = &tls.Config{InsecureSkipVerify: skipReadCert}
 	}
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = config
 }

--- a/pkg/plugins/identity/oidc/provider.go
+++ b/pkg/plugins/identity/oidc/provider.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	ProviderName = "oidc"
-	True         = "true"
+	ProviderName      = "oidc"
+	True              = "true"
+	FailCallConfigUrl = "Failed accessing config url, you need to continue to input missing information."
 )
 
 func init() {
@@ -185,7 +186,8 @@ func readConfigs(p *oidcIdentityProvider, configSet config.ConfigurationSet, con
 		if caCert != "" {
 			SetTransport(caCert)
 		} else {
-			p.logger.Errorf("CA cert is required to call the config url.")
+			p.logger.Warnf("CA cert is required to call the config url.")
+			p.logger.Info(FailCallConfigUrl)
 			return
 		}
 	}
@@ -195,6 +197,7 @@ func readConfigs(p *oidcIdentityProvider, configSet config.ConfigurationSet, con
 		addItems(p, configSet, res.Body())
 	} else {
 		p.logger.Errorf("Error calling config URL, error is: %w", err)
+		p.logger.Info(FailCallConfigUrl)
 	}
 }
 

--- a/pkg/plugins/identity/oidc/provider.go
+++ b/pkg/plugins/identity/oidc/provider.go
@@ -70,10 +70,11 @@ type oidcIdentityProvider struct {
 }
 
 type providerConfig struct {
-	OidcServer string `json:"oidc-server"`
-	OidcId     string `json:"oidc-client-id"`
-	OidcSecret string `json:"oidc-client-secret"`
-	UsePkce    string `json:"oidc-use-pkce"`
+	OidcServer        string `json:"oidc-server"`
+	OidcId            string `json:"oidc-client-id"`
+	OidcSecret        string `json:"oidc-client-secret"`
+	UsePkce           string `json:"oidc-use-pkce"`
+	SkipOidcTlsVerify string `json:"skip-oidc-ssl"`
 }
 
 func (p *oidcIdentityProvider) Name() string {
@@ -92,10 +93,11 @@ func (p *oidcIdentityProvider) Authenticate(ctx context.Context, input *identity
 	}
 
 	id := &oidc.Identity{
-		OidcServer: cfg.OidcServer,
-		OidcId:     cfg.OidcId,
-		OidcSecret: cfg.OidcSecret,
-		UsePkce:    cfg.UsePkce,
+		OidcServer:        cfg.OidcServer,
+		OidcId:            cfg.OidcId,
+		OidcSecret:        cfg.OidcSecret,
+		UsePkce:           cfg.UsePkce,
+		SkipOidcTlsVerify: cfg.SkipOidcTlsVerify,
 	}
 
 	ids, err := p.readRequiredFields(*id)
@@ -126,7 +128,9 @@ func executeOidcLogin(id oidc.Identity) error {
 	} else {
 		args = append(args, "--oidc-client-secret="+id.OidcSecret)
 	}
-	args = append(args, "--insecure-skip-tls-verify")
+	if id.SkipOidcTlsVerify == True {
+		args = append(args, "--insecure-skip-tls-verify")
+	}
 
 	cmd := exec.Command("kubectl", args...)
 	_, err := cmd.Output()

--- a/pkg/plugins/identity/plugins.go
+++ b/pkg/plugins/identity/plugins.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/fidelity/kconnect/pkg/plugins/identity/aws/iam"
 	_ "github.com/fidelity/kconnect/pkg/plugins/identity/azure/aad"
 	_ "github.com/fidelity/kconnect/pkg/plugins/identity/azure/env"
+	_ "github.com/fidelity/kconnect/pkg/plugins/identity/oidc"
 	_ "github.com/fidelity/kconnect/pkg/plugins/identity/rancher/activedirectory"
 	_ "github.com/fidelity/kconnect/pkg/plugins/identity/saml"
 	_ "github.com/fidelity/kconnect/pkg/plugins/identity/static/token"

--- a/pkg/utils/prerequisites.go
+++ b/pkg/utils/prerequisites.go
@@ -73,3 +73,13 @@ func CheckKubeloginPrereq() error {
 	}
 	return nil
 }
+
+func CheckKubectlOidcLoginPrereq() error {
+
+	cmd := exec.Command("kubectl", "oidc-login", "version")
+	_, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("error finding kubectl oidc-login: %w", err)
+	}
+	return nil
+}

--- a/scripts/install-kconnect.sh
+++ b/scripts/install-kconnect.sh
@@ -152,13 +152,15 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     aws_iam_authenticator_url=$(echo "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/vTAG/aws-iam-authenticator_TAG_windows_amd64.exe" | sed "s/TAG/$latest_aws_iam_authenticator_release_tag/g" )
     kubelogin_url=$(echo "https://github.com/Azure/kubelogin/releases/download/TAG/kubelogin-win-amd64.zip" | sed "s/TAG/$latest_kubelogin_release_tag/")
     azure_url=$(echo "https://github.com/Azure/azure-cli/releases/download/TAG/TAG.msi" | sed "s/TAG/$latest_azure_cli_release_tag/g")
-    
+    oidc_login_url=$(echo "https://github.com/int128/kubelogin/releases/download/TAG/kubelogin_windows_amd64.zip" | sed "s/TAG/$latest_oidc_login_release_tag/" )
+
     echo "kconnect url: $kconnect_url" 
     echo "kubectl url: $kubectl_url"
     echo "helm url: $helm_url"
     echo "aws_iam_authenticator url: $aws_iam_authenticator_url"
     echo "kubelogin url: $kubelogin_url"
     echo "azure url: $azure_url"
+    echo "oidc-login url: $oidc_login_url"
 
     # download 
     curl -k -s -L $kconnect_url -o kconnect.zip
@@ -166,12 +168,15 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     curl -k -s -L $helm_url -o helm.zip
     curl -k -s -L $aws_iam_authenticator_url -o aws-iam-authenticator.exe
     curl -k -s -L $kubelogin_url -o kubelogin.zip
+    curl -s -L $oidc_login_url -o oidclogin.zip
     curl -k -s -LO $azure_url
 
     # unzip
     unzip -qq kconnect.zip
     unzip -qq helm.zip
     mv windows-amd64/helm.exe .
+    unzip -qq oidclogin.zip
+    mv kubelogin.exe kubectl-oidc_login.exe
     unzip -qq kubelogin.zip
     mv bin/windows_amd64/kubelogin.exe .
 
@@ -180,6 +185,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     rm -f helm.zip
     rm -rf windows-amd64
     rm -f kubelogin.zip
+    rm -f oidclogin.zip
     rm -rf bin
 
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

User start to use EKS, but use Azure AD and OIDC protocol, for authentication and authorization, which current Kconnect doesn't support.

**Major Changes**:

**1.** Added new command, kconnect use oidc
**2.** The support for OIDC, is through kubectl extension, and authentication and authorization will happened when user executing kubectl commands, so just generate kubeconfig file and set contexts. No Authentication and Discovery happened.
**3.** New feature: Read config from https server, and combine them together with default config file and command parameters.

**Which issue(s) this PR fixes** 
Fixes #554 