### PR TITLE
fix: Respecting -k parameter in "kconnect to"

### DIFF
--- a/pkg/app/to.go
+++ b/pkg/app/to.go
@@ -83,6 +83,7 @@ func (a *App) ConnectTo(ctx context.Context, params *ConnectToInput) error {
 	useParams.SetCurrent = params.SetCurrent
 	useParams.IgnoreAlias = true
 	useParams.Alias = entry.Spec.Alias
+	useParams.Kubeconfig = params.Kubeconfig
 
 	return a.Use(ctx, useParams)
 }

--- a/pkg/app/to.go
+++ b/pkg/app/to.go
@@ -83,7 +83,11 @@ func (a *App) ConnectTo(ctx context.Context, params *ConnectToInput) error {
 	useParams.SetCurrent = params.SetCurrent
 	useParams.IgnoreAlias = true
 	useParams.Alias = entry.Spec.Alias
-	useParams.Kubeconfig = params.Kubeconfig
+	if params.Kubeconfig != "" {
+		useParams.Kubeconfig = params.Kubeconfig
+	} else {
+		useParams.Kubeconfig = entry.Spec.ConfigFile
+	}
 
 	return a.Use(ctx, useParams)
 }

--- a/pkg/history/store.go
+++ b/pkg/history/store.go
@@ -254,6 +254,7 @@ func (s *storeImpl) filterHistory(filter func(entry *historyv1alpha.HistoryEntry
 
 func (s *storeImpl) connectionExists(entry *historyv1alpha.HistoryEntry, historyList *historyv1alpha.HistoryEntryList) (*historyv1alpha.HistoryEntry, bool) {
 	for _, existingEntry := range historyList.Items {
+		entry.Spec.ConfigFile = existingEntry.Spec.ConfigFile // Ignore this field to prevent a duplicated alias from being created if the user passed -k
 		if existingEntry.Equals(entry) {
 			return &existingEntry, true
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes the `to` sub command respect the -k flag. It also makes `to -` respect the config file path stored in the history entry.

It will leave the history entry untouched, meaning the next call to `to` will revert back to the config file passed when creating the entry.

I had to prevent the history entries from comparing on the config file field, as doing so leads to the duplication of entries when using -k, which then in turn breaks the alias until the file is edited by hand.
With the below change the config file is not considered during history entry comparisons.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #352
Replaces PR #409 - The comment made in that PR is also addressed here