### PR TITLE
feat(eks): cross-account support

### DIFF
--- a/docs/book/src/commands/use_eks.md
+++ b/docs/book/src/commands/use_eks.md
@@ -52,6 +52,7 @@ kconnect use eks [flags]
 
 ```bash
   -a, --alias string                         Friendly name to give to give the connection
+      --assume-role-arn string               ARN of the AWS role to be assumed
       --aws-shared-credentials-file string   Location to store AWS credentials file
   -c, --cluster-id string                    Id of the cluster to use.
   -h, --help                                 help for eks
@@ -65,7 +66,7 @@ kconnect use eks [flags]
       --password string                      The password to use for authentication
       --region string                        AWS region to connect to
       --region-filter string                 A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions
-      --role-arn string                      ARN of the AWS role to be assumed
+      --role-arn string                      ARN of the AWS role to be logged in with
       --role-filter string                   A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name
       --set-current                          Sets the current context in the kubeconfig to the selected cluster (default true)
       --username string                      The username used for authentication

--- a/pkg/plugins/discovery/aws/provider.go
+++ b/pkg/plugins/discovery/aws/provider.go
@@ -71,10 +71,11 @@ func New(input *provider.PluginCreationInput) (discovery.Provider, error) {
 
 type eksClusteProviderConfig struct {
 	common.ClusterProviderConfig
-	Region       *string `json:"region"`
-	RegionFilter *string `json:"region-filter"`
-	RoleArn      *string `json:"role-arn"`
-	RoleFilter   *string `json:"role-filter"`
+	AssumeRoleARN *string `json:"assume-role-arn"`
+	Region        *string `json:"region"`
+	RegionFilter  *string `json:"region-filter"`
+	RoleArn       *string `json:"role-arn"`
+	RoleFilter    *string `json:"role-filter"`
 }
 
 // EKSClusterProvider will discover EKS clusters in AWS
@@ -129,8 +130,9 @@ func ConfigurationItems(scopeTo string) (config.ConfigurationSet, error) {
 	cs := aws.SharedConfig()
 
 	cs.String("aws-shared-credentials-file", os.Getenv("AWS_SHARED_CREDENTIALS_FILE"), "Location to store AWS credentials file")
+	cs.String("assume-role-arn", "", "ARN of the AWS role to be assumed")
 	cs.String("region-filter", "", "A regex filter to apply to the AWS regions list, e.g. '^us-|^eu-' will only show US and eu regions") //nolint: errcheck
-	cs.String("role-arn", "", "ARN of the AWS role to be assumed")                                                                       //nolint: errcheck
+	cs.String("role-arn", "", "ARN of the AWS role to be logged in with")                                                                //nolint: errcheck
 	cs.String("role-filter", "", "A filter to apply to the roles list, e.g. 'EKS' will only show roles that contain EKS in the name")    //nolint: errcheck
 
 	return cs, nil

--- a/pkg/plugins/identity/saml/saml.go
+++ b/pkg/plugins/identity/saml/saml.go
@@ -184,6 +184,7 @@ func (p *samlIdentityProvider) bindAndValidateConfig(cs config.ConfigurationSet)
 
 func (p *samlIdentityProvider) createAccount(cs config.ConfigurationSet) (*cfg.IDPAccount, error) {
 	account := &cfg.IDPAccount{
+		Username:        p.config.Username,
 		URL:             p.config.IdpEndpoint,
 		Provider:        p.config.IdpProvider,
 		MFA:             "Auto",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will allow EKS users to leverage cross-account support. This means the feature will allow users to provide a new flag called `--assume-role-arn`, `kconnect` will login will the main credentials, and then switch to a different AWS IAM role within another AWS Account.

This is helpful for users who want to be part of a single AD group in a central AWS account, which then assumes and gives access to any EKS cluster instead of having to be in several different AD groups for each AWS account.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Testing**:
- `make ci` completed successfully
- was able to connect to a cluster, and assume the new AWS IAM role
```
% ./kconnect use eks --namespace <namespace --region us-east-1 --username *** --password *** --assume-role-arn arn:aws:iam::<AWS-account>:role/<AWS-IAM-role>
info    kconnect - the Kubernetes Connection Manager CLI        {"version": ""}
info    authenticating user     {"app": "kconnect", "provider": "saml"}
? Select AWS role Account: <AWS-account-name> (<AWS-account>) / <AWS-IAM-role>
info    requesting AWS credentials using SAML   {"provider": "saml", "sp": "aws"}
info    discovering clusters    {"app": "kconnect", "provider": "eks"}
info    discovering EKS clusters        {"app": "kconnect", "provider": "eks"}
? Select a cluster <cluster-name>
? Do you want to set an alias? No
info    Command to reconnect using this alias: kconnect to      {"app": "kconnect"}
info    setting current context {"context": "kconnect@<eks-cluster-name>"}
info    kubeconfig updated      {"path": "/path/to/KUBECONFIG"}

% ./kconnect ls | head -n 3                                                                                                                                                     
info    kconnect - the Kubernetes Connection Manager CLI        {"version": ""}
CUR   ID                           ALIAS    PROVIDER   PROVIDERID               IDENTITY   USER     TIME LEFT
>     01hffm07j9m8ck60t3w3cjr5zy            eks        arn:aws:eks:<provider>   saml       <user>   59m53s

% kubectl get nodes
Error from server (Forbidden): nodes is forbidden: User "arn:aws:iam::<AWS-assumed-account>:role/<AWS-assumed-IAM-role>" cannot list resource "nodes" in API group "" at the cluster scope
```