### PR TITLE
feat(actions): upgrade the goreleaser step to version 5, and setup-go version to 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v3
               with:
-                  go-version: '1.20'
+                  go-version: '1.22'
             - name: Login to DockerHub
               uses: docker/login-action@v2
               with:
@@ -34,7 +34,7 @@ jobs:
             #   env:
             #     SNAP_TOKEN: ${{secrets.SNAP_LOGIN}}
             - name: Run GoReleaser
-              uses: goreleaser/goreleaser-action@v3
+              uses: goreleaser/goreleaser-action@v5
               with:
                   version: latest
                   args: release --clean

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -2,6 +2,8 @@ name: titlecheck
 
 # Run on PR
 on:
+  # enable for testing new changes
+  # pull_request:
   pull_request_target:
     types:
       - opened
@@ -20,6 +22,6 @@ jobs:
         success-state: Title follows the specification.
         failure-state: Title does not follow the specification.
         context-name: conventional-pr-title
-        preset: conventional-changelog-angular@latest
+        preset: conventional-changelog-angular@7.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@v2.2.5
+      uses: aslafy-z/conventional-pr-title-action@v3.2.0
       with:
         success-state: Title follows the specification.
         failure-state: Title does not follow the specification.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,7 +62,7 @@ brews:
       - aws-iam-authenticator
       - Azure/kubelogin/kubelogin
       - kubernetes-cli
-    folder: Formula
+    directory: Formula
 
 dockers:
   -


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is needed to fix the deprecated message `'DEPRECATED: brews.folder should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info'`, and to fix the issue `'unknown directive: toolchain'` which is introduced, because we upgraded the source code to use go1.22, but not the GitHub Action

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/fidelity/kconnect/actions/runs/8986941097/job/24684255990

### Testing
Enabled the `pull_request` trigger to test the GitHub action changes before merging to the `main` branch, and the GitHub action changes completed successfully:
<img width="1512" alt="Screenshot 2024-05-07 at 11 44 11 AM" src="https://github.com/fidelity/kconnect/assets/4017416/58625d94-27d0-4dfb-bb09-de96f43f91f4">

***This branch can be deleted once it is merged.***