### PR TITLE
feat(actions): add git.prerelease_suffix within .goreleaser.yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,13 @@ before:
     hooks:
      - go mod download
 
+git:
+  # What should be used to specify prerelease suffix while sorting tags when gathering
+  # the current and previous tags if there are more than one tag in the same commit.
+  #
+  # Since: v1.17 of goreleaser
+  prerelease_suffix: "-"
+
 builds:
     -
       id: default


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is needed to prevent the prerelease version from being the latest version. The `goreleaser` GitHub action unfortunately does not enable this setting by default, https://github.com/goreleaser/goreleaser/blob/main/internal/pipe/git/git.go#L311. Therefore, we need to enable this setting because more often than not the prerelease tag is the same commit as the release tag.

[For more information about the git.prerelease_suffix setting](https://goreleaser.com/customization/git/?h=prerelease_suffix)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # the `goreleaser` GitHub action from getting the wrong version:
```
  • getting and validating git state
    • git state                                      
       commit=fb0dbcee9fed2ccf5195f326e931f9f7daf2392b branch=HEAD 
       current_tag=0.5.16-rc.1 previous_tag=0.5.15-rc.1 dirty=false
...
⨯ release failed after 3m59s               
   error=scm releases: failed to publish artifacts: failed to upload kconnect_linux_arm64.tar.gz
    after 1 tries: POST https://uploads.github.com/repos/fidelity/kconnect/releases/154868838/assets?name=kconnect_linux_arm64.tar.gz:
     422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```

### Testing
This is the current default output from the `goreleaser` GitHub action:
```
% git tag --sort="-version:refname"    
0.5.16-rc.1
0.5.16
0.5.15-rc.1
0.5.15
...
```

With this change here is the new output:
```
% git -c versionsort.suffix=- tag --points-at HEAD --sort -version:refname --format='%(creatordate)%09%(refname)'
Wed May 8 21:57:17 2024 -0400   refs/tags/0.5.16
Wed May 8 21:49:16 2024 -0400   refs/tags/0.5.16-rc.1
```
Which is what we want, and will ideally fix the issue.

***This branch can be deleted once it is merged.***