### PR TITLE
feat(aks): update the aad protocal to try interactive login no matter the failure

### DIFF
--- a/pkg/plugins/identity/azure/aad/aad.go
+++ b/pkg/plugins/identity/azure/aad/aad.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/zap"
@@ -140,14 +139,13 @@ func (p *aadIdentityProvider) Authenticate(ctx context.Context, input *provid.Au
 	err = cmd.Run()
 
 	if err != nil {
-		if strings.Contains(stderr.String(), "Interactive authentication is needed.") {
-			interactiveLoginRequired = true
-			cmd = exec.Command("az", "login", "--tenant", cfg.TenantID)
-			cmd.Stdout = nil
-			cmd.Stdin = os.Stdin
-			cmd.Stderr = os.Stderr
-			cmd.Run()
-		} else {
+		interactiveLoginRequired = true
+		cmd = exec.Command("az", "login", "--tenant", cfg.TenantID)
+		cmd.Stdout = nil
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
 			return nil, fmt.Errorf("azure cli: %w", err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will update the Azure AAD protocol to try an interactive login if the non-interactive login fails for any reason. If the interactive login also fails, then we return an error. We have noticed that some users receive different error messages when attempting to do a non-interactive login, so this change will hopefully cover those other error messages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Users were seeing the following error message:
```
C:> az login -u XXX -p XXX
(pii). Status: Response_Status.Status_InteractionRequired, Error code: 3399614476, Tag: 557973645
Please explicitly log in with:
az login
```
Instead of the expected error message of `"Interactive authentication is needed."`

***This branch can be deleted once it is merged.***