### PR TITLE
feat(Dockerfiles): upgrade dependencies within the Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM alpine:3.19 AS certs
-RUN apk --update add ca-certificates
-RUN adduser -D kconnect
+FROM alpine:3.20 AS certs
+RUN apk --update add ca-certificates && adduser -D kconnect
 
 FROM scratch
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY  kconnect /
+COPY kconnect /
 
 COPY --from=certs /etc/passwd /etc/passwd
 COPY --from=certs /home /home

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,8 +1,7 @@
-FROM alpine:3.19
+FROM alpine:3.20
 
-RUN apk --no-cache add ca-certificates
-COPY  kconnect /
+RUN apk --no-cache add ca-certificates && adduser -D kconnect
+COPY kconnect /
 
-RUN adduser -D kconnect
 USER kconnect
 ENTRYPOINT ["/kconnect"]

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,10 +1,10 @@
-FROM alpine:3.19 AS builder
+FROM alpine:3.20 AS builder
 
-ARG AWS_IAM_AUTH_VERSION=0.6.14
-ARG ODIC_LOGIN_VERSION=1.28.0
-ARG KUBELOGIN_VERSION=0.1.3
-ARG KUBECTL_VERSION=1.31.0
-ARG HELM_VERSION=3.13.3
+ARG AWS_IAM_AUTH_VERSION=0.6.29
+ARG ODIC_LOGIN_VERSION=1.31.1
+ARG KUBELOGIN_VERSION=0.1.6
+ARG KUBECTL_VERSION=1.32.0
+ARG HELM_VERSION=3.16.4
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -36,7 +36,8 @@ RUN curl -L \
 RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -o helm.tar.gz && \
     tar xvfz helm.tar.gz
 
-FROM mcr.microsoft.com/azure-cli:2.56.0
+# Azure CLI
+FROM mcr.microsoft.com/azure-cli:2.67.0
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /app/

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.13
-	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
-	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
-	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e // indirect
-	github.com/PuerkitoBio/goquery v1.9.2 // indirect
-	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/beevik/etree v1.4.1
 	github.com/blang/semver v3.5.1+incompatible
@@ -21,26 +16,17 @@ require (
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/marshallbrekka/go-u2fhost v0.0.0-20210111072507-3ccdec8c8105 // indirect
-	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spf13/afero v1.11.0 // indirect
-	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/versent/saml2aws/v2 v2.36.17
-	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0
-	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/mod v0.22.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -48,7 +34,6 @@ require (
 	k8s.io/cli-runtime v0.32.0
 	k8s.io/client-go v0.32.0
 	sigs.k8s.io/yaml v1.4.0
-
 )
 
 require (
@@ -57,8 +42,13 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.22 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.6 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e // indirect
+	github.com/PuerkitoBio/goquery v1.9.2 // indirect
+	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/bearsh/hid v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -75,6 +65,8 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -83,8 +75,11 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/marshallbrekka/go-u2fhost v0.0.0-20210111072507-3ccdec8c8105 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -94,12 +89,16 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.11.0 // indirect
+	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/trimble-oss/go-webauthn-client v0.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
- This change will upgrade the various binaries mentioned within the three different Dockerfiles. We need to keep the binaries up to date to leverage either security fixes, or new features
- Also, a bit of organizational change, we grouped all of the indirect dependencies to their own require block in the go.mod file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Need to upgrade dependencies.