### PR TITLE
feat(Dockerfile.deps): switch to python:alpine base image

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -36,9 +36,7 @@ RUN curl -L \
 RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -o helm.tar.gz && \
     tar xvfz helm.tar.gz
 
-# Azure CLI
-FROM mcr.microsoft.com/azure-cli:2.67.0
-RUN apk --no-cache add ca-certificates
+FROM python:alpine
 
 WORKDIR /app/
 ENV PATH="/app:${PATH}"
@@ -53,6 +51,10 @@ COPY --from=builder bin/${TARGETOS}_${TARGETARCH}/kubelogin .
 COPY --from=builder ${TARGETOS}-${TARGETARCH}/helm .
 COPY kconnect .
 
-RUN adduser -D kconnect
+# Azure CLI
+RUN apk --no-cache add ca-certificates cargo gcc libffi-dev make musl-dev openssl-dev python3-dev && \
+    pip install --upgrade pip && \
+    pip install azure-cli && \
+    adduser -D kconnect
 USER kconnect
 ENTRYPOINT ["/app/kconnect"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will avoid using the `Microsoft Azure CLI` Docker image, because the newer versions contain `Azure Linux` operating system instead of `Alpine`. This change in operating system can cause issues for users building on top of this image. Therefore introducing a breaking change, which I think we should try to avoid.

I used this GitHub issue for reference: https://github.com/Azure/azure-cli/issues/19591

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # The new `mcr.microsoft.com/azure-cli:2.67.0` Docker image has migrated to using `Azure Linx` instead of `Alpine` for the underlying operating system: https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker?view=azure-cli-latest

This causes the current `Dockerfile.deps` to fail during the `goreleaser` GitHub Action:
```
> [stage-1  2/10] RUN apk --no-cache add ca-certificates:
0.146 /bin/sh: line 1: apk: command not found
------
Dockerfile:41
--------------------
  39 |     # Azure CLI
  40 |     FROM mcr.microsoft.com/azure-cli:2.67.0
  41 | >>> RUN apk --no-cache add ca-certificates
  42 |     
  43 |     WORKDIR /app/
--------------------
ERROR: failed to solve: process "/bin/sh -c apk --no-cache add ca-certificates" did not complete successfully: exit code: 127
```
https://github.com/fidelity/kconnect/actions/runs/13575743025/job/37951438546

### Testing
I created a Pre-release tag on this `bugfix` branch to make sure that these changes would pass the `goreleaser` GitHub Action.
https://github.com/fidelity/kconnect/actions/runs/13640814861

***This branch can be deleted once it is merged.***