### PR TITLE
feat(aws): set maximum number of retries for AWS session

### DIFF
--- a/pkg/aws/clients.go
+++ b/pkg/aws/clients.go
@@ -34,7 +34,8 @@ import (
 
 func NewSession(region, profile, accessKey, secretKey, sessionToken, awsSharedCredentialsFile string) (*session.Session, error) {
 	cfg := aws.Config{
-		Region: aws.String(region),
+		Region:     aws.String(region),
+		MaxRetries: aws.Int(5), // set the maximum number of retries
 	}
 
 	if profile != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
caps the numbers of AWS connect retries to 5

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #