### PR TITLE
feat(actions): migrate titlecheck workflow to amannn/action-semantic-pull-request@v5

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -17,11 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check conventinal title
-      uses: aslafy-z/conventional-pr-title-action@v3.2.0
-      with:
-        success-state: Title follows the specification.
-        failure-state: Title does not follow the specification.
-        context-name: conventional-pr-title
-        preset: conventional-changelog-angular@7.0.0
+      uses: amannn/action-semantic-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will migrate the `titlecheck` GitHub workflow from `aslafy-z/conventional-pr-title-action@v3.2.0` to `amannn/action-semantic-pull-request@v5`, because the GitHub Action `aslafy-z/conventional-pr-title-action` has been archived, and will no longer receive updates. Therefore, we should look to use an alternative GitHub Action that is being actively worked on. The archive notice on the GitHub repository mentions this `amannn/action-semantic-pull-request` GitHub Action as an alternative with mostly similar functionalities, and it is recommended.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/aslafy-z/conventional-pr-title-action?tab=readme-ov-file#important-notice-this-repository-has-been-archived

***This branch can be deleted once it is merged.***