### PR TITLE
feat(deps): upgrade dependencies in Dockerfiles, and update goreleaser config

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -16,6 +16,7 @@ jobs:
           submodules: true
       - name: Build Docs
         run: |
+          sudo apt-get update && sudo apt-get install -y libudev-dev
           make docs-build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Run GoReleaser
               uses: goreleaser/goreleaser-action@v5
               with:
-                  version: latest
+                  version: "~> v2"
                   args: release --clean
               env:
                   GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   titlecheck:
-    name: PR title follows coventional commit
+    name: PR title follows conventional commit
     runs-on: ubuntu-latest
     steps:
-    - name: Check conventinal title
+    - name: Check conventional title
       uses: amannn/action-semantic-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,19 +35,19 @@ release:
 archives:
     -
       id: default
-      builds:
+      ids:
         - default
       name_template: '{{ .ProjectName }}_{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
-      format: tar.gz
+      formats: [tar.gz]
       format_overrides:
           - goos: windows
-            format: zip
+            formats: [zip]
 
 checksum:
     name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-    name_template: "{{ .Tag }}-next"
+    version_template: "{{ .Tag }}-next"
 
 changelog:
     sort: asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 AS certs
+FROM alpine:3.21 AS certs
 RUN apk --update add ca-certificates && adduser -D kconnect
 
 FROM scratch

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.21
 
 RUN apk --no-cache add ca-certificates && adduser -D kconnect
 COPY kconnect /

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,10 +1,15 @@
-FROM alpine:3.20 AS builder
+FROM alpine:3.21 AS builder
+# https://github.com/kubernetes-sigs/aws-iam-authenticator
+ARG AWS_IAM_AUTH_VERSION=0.7.4
+# https://github.com/int128/kubelogin
+ARG ODIC_LOGIN_VERSION=1.33.0
+# https://github.com/Azure/kubelogin
+ARG KUBELOGIN_VERSION=0.2.9
+# https://github.com/kubernetes/kubectl
+ARG KUBECTL_VERSION=1.32.6
+# https://github.com/helm/helm
+ARG HELM_VERSION=3.18.4
 
-ARG AWS_IAM_AUTH_VERSION=0.6.29
-ARG ODIC_LOGIN_VERSION=1.31.1
-ARG KUBELOGIN_VERSION=0.1.6
-ARG KUBECTL_VERSION=1.32.0
-ARG HELM_VERSION=3.16.4
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ release: # Builds a release
 	goreleaser
 
 .PHONY: release-local
-release-local: # Builds a relase locally
+release-local: # Builds a release locally
 	goreleaser --snapshot --skip=publish --clean
 
 ##@ Test & CI


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will upgrade the dependencies referenced within the different `Dockerfiles`, as well as update the `goreleaser` configuration yaml file. There were some deprecated fields, and have been updated to the new field, or syntax format.

This change will also add a missing package `libudev-dev` to resolve the issue with the `build-docs` GitHub Action. The `libudev-dev` package is required by the `github.com/bearsh/hid` package, which is indirectly referenced by the `github.com/versent/saml2aws/v2` package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/fidelity/kconnect/actions/runs/16240710616/job/45856725583
```
# github.com/bearsh/hid/libusb/libusb/os/udev
# [pkg-config --cflags  -- libudev]
Package libudev was not found in the pkg-config search path.
Perhaps you should add the directory containing `libudev.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libudev', required by 'virtual:world', not found
make: *** [Makefile:129: hack/tools/bin/cmddocsgen] Error 1
Error: Process completed with exit code 2.
```

***This branch can be deleted once it is merged.***