### PR TITLE
fix(krew): update krew.yaml to correct URL typo

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -7,13 +7,13 @@ spec:
   homepage: https://github.com/fidelity/kconnect
   shortDescription: "Discover and access clusters"
   description: |
-    kconnect is a tool that can be used to discover and securely access Kubernetes 
+    kconnect is a tool that can be used to discover and securely access Kubernetes
     clusters across multiple operating environments.
-    Based on the authentication mechanism chosen the CLI will discover Kubernetes 
-    clusters you are allowed to access in a target hosting environment (i.e. EKS, AKS, Rancher) 
+    Based on the authentication mechanism chosen the CLI will discover Kubernetes
+    clusters you are allowed to access in a target hosting environment (i.e. EKS, AKS, Rancher)
     and generate a kubeconfig for a chosen cluster.
     Features:
-    - Authenticate using SAML or Azure Active Directory 
+    - Authenticate using SAML or Azure Active Directory
     - Discover EKS, AKS & Rancher clusters
     - Generate a kubeconfig for a cluster
     - Query history of connected servers
@@ -59,7 +59,7 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/fidelity/kconnect/releases/download/{{ .TagName }}/kconnect_macos_amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/fidelity/kconnect/releases/download/{{ .TagName }}/kconnect_macos_arm64.tar.gz" .TagName }}
     files:
     - from: "kconnect"
       to: "kubectl-connect"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will update the `.krew.yaml` file by changing the "addURIAndSha" template from `kconnect_macos_amd64` to `kconnect_macos_arm64` for the `arm64` plugin. This was a typo and was causing the "krew-index" to reference the `kconnect_macos_amd64` release for both `amd64` and `arm64`, which we can see in the following link:
- https://github.com/fidelity/krew-index/blob/kconnect-0.5.21/plugins/connect.yaml#L66

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # typo in `.krew.yaml` that was referencing the wrong SHA for the `arm64` plugin.

***This branch can be deleted once that it is merged.***