### PR TITLE
fix(actions): upgrade golangci/golangci-lint-action from v8 to v9, and add constant for duplicate string

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config gcc g++ libusb-1.0-0-dev libudev-dev libhidapi-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         env:
           CGO_ENABLED: 1
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - gocritic
     - godot
     - godox
+    - gomodguard
     - gosec
     - gosmopolitan
     - govet

--- a/api/v1alpha1/configuration_types.go
+++ b/api/v1alpha1/configuration_types.go
@@ -97,11 +97,11 @@ func (c *Configuration) ToTable() *metav1.Table {
 		ColumnDefinitions: []metav1.TableColumnDefinition{
 			{
 				Name: "Provider",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "App Defaults",
-				Type: "string",
+				Type: StringType,
 			},
 		},
 	}

--- a/api/v1alpha1/history_types.go
+++ b/api/v1alpha1/history_types.go
@@ -31,6 +31,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
+const (
+	StringType = "string"
+)
+
 // HistoryEntrySpec represents a history item
 type HistoryEntrySpec struct {
 	// Provider is the name of the discovery provider
@@ -199,35 +203,35 @@ func (l *HistoryEntryList) ToTable(currentContextID string) *metav1.Table {
 		ColumnDefinitions: []metav1.TableColumnDefinition{
 			{
 				Name: "Cur",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "Id",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "Alias",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "Provider",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "ProviderID",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "Identity",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "User",
-				Type: "string",
+				Type: StringType,
 			},
 			{
 				Name: "Time left",
-				Type: "String",
+				Type: StringType,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This change will upgrade `golangci/golangci-lint-action` from `v8` to `v9`, because `Node20` has reached its end of life, and there is a new version of `golangci/golangci-lint-action` that now supports `Node24`. Also, we created a constant `StringType` to replace the duplicate strings since the lint GitHub action was failing.

For more information on the deprecation of `Node20`: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/fidelity/kconnect/actions/runs/26051077384/job/76587529519
```
Error: api/v1alpha1/configuration_types.go:100:11: string `string` has 9 occurrences, make it a constant (goconst)
			Type: "string",
				  ^
Error: api/v1alpha1/history_types.go:202:11: string `string` has 9 occurrences, make it a constant (goconst)
			Type: "string",
				  ^
2 issues:
* goconst: 2

level=warning msg="The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2."
level=warning msg="Suggested new configuration:\nlinters:\n  enable:\n    - gomodguard_v2\n"

Error: issues found
Ran golangci-lint in 43306ms
```

This branch can be deleted once it is merged.