### PR TITLE
feat(script): add support for cygwin to install-kconnect.sh

### DIFF
--- a/scripts/install-kconnect.sh
+++ b/scripts/install-kconnect.sh
@@ -143,7 +143,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     chmod +x kubelogin
     chmod +x kubectl-oidc_login
 
-elif [[ "$OSTYPE" == "msys" ]]; then
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     # Win git bash
 
     kconnect_url=$(echo "https://github.com/fidelity/kconnect/releases/download/TAG/kconnect_windows_amd64.zip" | sed "s/TAG/$latest_kconnect_release_tag/" )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will add the `cygwin` OS type to the `install-kconnect.sh` script. This will add support for users that are trying to install kconnect, and the additional binaries on their Cygwin systems.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # user reported issue.

***This branch can be deleted once it is merged.***